### PR TITLE
add olw setup wizard and zero-friction onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The wiki lives in Obsidian, so you get the graph view, backlinks, and Dataview q
 - **Wiki health checks** — `olw lint` detects orphans, broken links, stale articles (no LLM needed)
 - **Query your wiki** — `olw query "what is X?"` answers from your published articles
 - **Git safety net** — every auto-action is committed; `olw undo` reverts safely
-- **Offline test suite** — all 117 tests run without Ollama
+- **Offline test suite** — all 139 tests run without Ollama
 
 ---
 
@@ -65,7 +65,17 @@ python install.py
 
 `install.py` detects `uv` or falls back to `pip`, verifies the install, and tells you to run the next step.
 
-### 2. Run the setup wizard
+### 2. Install and start Ollama
+
+```bash
+# Install Ollama: https://ollama.com/download
+ollama pull gemma4:e4b      # fast model — analysis and routing
+ollama pull qwen2.5:14b     # heavy model — article writing (optional, 7B+ recommended)
+```
+
+> **Minimal setup:** pull only `gemma4:e4b` and set both `fast` and `heavy` to it in the wizard.
+
+### 3. Run the setup wizard
 
 ```bash
 olw setup
@@ -83,23 +93,13 @@ An interactive wizard configures your Ollama URL, fast and heavy models, and an 
 
   Step 2/4  Fast model (analysis · 3–8B recommended)
     #  Model           Size
-    1  gemma4:e4b      4.3 GB
-    2  llama3.2:3b     2.0 GB
+    1  gemma4:e4b      9.6 GB
+    2  phi4-mini       2.5 GB
     Select (number or name) [1]: _
   ...
 ```
 
 Settings are saved to `~/.config/olw/config.toml` (Mac/Linux) or `%APPDATA%\olw\config.toml` (Windows).
-
-### 3. Install and start Ollama
-
-```bash
-# Install Ollama: https://ollama.com/download
-ollama pull gemma4:e4b      # fast model — analysis and routing
-ollama pull qwen2.5:14b     # heavy model — article writing (optional, 7B+ recommended)
-```
-
-> **Minimal setup:** set both `fast` and `heavy` to `gemma4:e4b` in `wiki.toml` to use a single model.
 
 ### 4. Set up your vault
 
@@ -215,7 +215,7 @@ heavy = "qwen2.5:14b"     # article generation, Q&A answers
 
 [ollama]
 url = "http://localhost:11434"   # supports LAN: http://192.168.1.x:11434
-timeout = 900
+timeout = 600
 
 [pipeline]
 auto_approve = false             # true = skip draft review

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ heavy = "qwen2.5:14b"     # article generation, Q&A answers
 [ollama]
 url = "http://localhost:11434"   # supports LAN: http://192.168.1.x:11434
 timeout = 600
+fast_ctx = 8192                  # context window for fast model (tokens)
+heavy_ctx = 16384                # context window for heavy model (tokens)
 
 [pipeline]
 auto_approve = false             # true = skip draft review
@@ -223,6 +225,21 @@ auto_commit = true               # git commit after each operation
 max_concepts_per_source = 8      # limit concepts extracted per note
 watch_debounce = 3.0             # seconds after last file event before processing
 ```
+
+### Tuning context windows
+
+`heavy_ctx` controls how much source material the heavy model reads when writing articles (`source budget = heavy_ctx / 2` chars) and how long the generated article can be. The default of `16384` is sized for 7–14B models. **If you use a model with a large context window (e.g. `gemma4:e4b` supports 128K), increase it.**
+
+| RAM available | Recommended `heavy_ctx` | Source budget | Notes |
+|---|---|---|---|
+| 8 GB | `8192` | ~4K chars | Minimum; short articles |
+| 16 GB | `16384` | ~8K chars | Default |
+| 16 GB+ | `32768` | ~16K chars | Recommended for `gemma4:e4b` |
+| 32 GB+ | `65536` | ~32K chars | Rich multi-source articles |
+
+`fast_ctx` (used for ingest/routing) rarely needs changing — single notes fit comfortably in 8K.
+
+After editing `wiki.toml`, no reinstall is needed. Run `olw compile --force` to regenerate articles with the new context budget.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,35 +47,69 @@ The wiki lives in Obsidian, so you get the graph view, backlinks, and Dataview q
 
 ### 1. Install
 
+**From PyPI** (recommended for most users):
+
 ```bash
 pip install obsidian-llm-wiki
-```
-
-Or with [uv](https://docs.astral.sh/uv/) (recommended):
-
-```bash
+# or with uv (faster):
 uv tool install obsidian-llm-wiki
 ```
 
-### 2. Install and start Ollama
+**From source** (clone and install with one command):
+
+```bash
+git clone https://github.com/kytmanov/obsidian-llm-wiki
+cd obsidian-llm-wiki
+python install.py
+```
+
+`install.py` detects `uv` or falls back to `pip`, verifies the install, and tells you to run the next step.
+
+### 2. Run the setup wizard
+
+```bash
+olw setup
+```
+
+An interactive wizard configures your Ollama URL, fast and heavy models, and an optional default vault path. Takes ~30 seconds.
+
+```
+╭──────────────────────────────────────────────────╮
+│      obsidian-llm-wiki  ·  first run setup       │
+╰──────────────────────────────────────────────────╯
+
+  Step 1/4  Ollama connection
+    Trying http://localhost:11434 …  ✓ connected
+
+  Step 2/4  Fast model (analysis · 3–8B recommended)
+    #  Model           Size
+    1  gemma4:e4b      4.3 GB
+    2  llama3.2:3b     2.0 GB
+    Select (number or name) [1]: _
+  ...
+```
+
+Settings are saved to `~/.config/olw/config.toml` (Mac/Linux) or `%APPDATA%\olw\config.toml` (Windows).
+
+### 3. Install and start Ollama
 
 ```bash
 # Install Ollama: https://ollama.com/download
-ollama pull gemma3:4b       # fast model — analysis and routing
+ollama pull gemma4:e4b      # fast model — analysis and routing
 ollama pull qwen2.5:14b     # heavy model — article writing (optional, 7B+ recommended)
 ```
 
-> **Minimal setup:** set both `fast` and `heavy` to `gemma3:4b` in `wiki.toml` to use a single model.
+> **Minimal setup:** set both `fast` and `heavy` to `gemma4:e4b` in `wiki.toml` to use a single model.
 
-### 3. Set up your vault
+### 4. Set up your vault
 
 ```bash
 olw init ~/my-wiki
 ```
 
-This creates the folder structure and a `wiki.toml` config file.
+This creates the folder structure and a `wiki.toml` pre-filled with your setup wizard choices.
 
-### 4. Add some notes
+### 5. Add some notes
 
 Drop any `.md` files into `~/my-wiki/raw/`. Web clips, book notes, meeting notes, anything.
 
@@ -86,25 +120,27 @@ Drop any `.md` files into `~/my-wiki/raw/`. Web clips, book notes, meeting notes
   physics-lecture.md
 ```
 
-### 5. Run the pipeline
+### 6. Run the pipeline
 
 ```bash
 # Analyze notes, extract concepts
-olw ingest --vault ~/my-wiki --all
+olw ingest --all
 
 # Generate wiki articles (lands in .drafts/)
-olw compile --vault ~/my-wiki
+olw compile
 
 # Review drafts, then publish
-olw approve --vault ~/my-wiki --all
+olw approve --all
 ```
+
+If you set a default vault in `olw setup`, the `--vault` flag is optional. Otherwise use `--vault ~/my-wiki` or `export OLW_VAULT=~/my-wiki`.
 
 Open `~/my-wiki` as an Obsidian vault. The graph view shows your connected wiki.
 
-### 6. Keep it running (optional)
+### 7. Keep it running (optional)
 
 ```bash
-olw watch --vault ~/my-wiki
+olw watch
 # Drop a file in raw/ → ingest + compile happen automatically
 ```
 
@@ -173,7 +209,7 @@ my-wiki/
 
 ```toml
 [models]
-fast = "gemma3:4b"        # extraction, analysis, query routing
+fast = "gemma4:e4b"        # extraction, analysis, query routing
 heavy = "qwen2.5:14b"     # article generation, Q&A answers
 # Single-model: set heavy = fast
 
@@ -194,6 +230,7 @@ watch_debounce = 3.0             # seconds after last file event before processi
 
 | Command | Description |
 |---------|-------------|
+| `olw setup` | Interactive setup wizard (first run) |
 | `olw init PATH` | Create vault structure and git repo |
 | `olw init PATH --existing` | Adopt an existing Obsidian vault |
 | `olw doctor` | Check Ollama, models, vault structure |
@@ -223,7 +260,7 @@ All commands accept `--vault PATH` or the env var `OLW_VAULT`.
 
 | Role | Recommended | Minimum |
 |------|-------------|---------|
-| Fast (analysis + routing) | `gemma3:4b`, `llama3.2:3b` | any 3B with JSON format |
+| Fast (analysis + routing) | `gemma4:e4b`, `llama3.2:3b` | any 3B with JSON format |
 | Heavy (article writing) | `qwen2.5:14b`, `llama3.1:8b` | any 7B |
 | Single model (everything) | `llama3.1:8b`, `mistral:7b` | any 7B |
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,67 @@ OLLAMA_URL=http://localhost:11434 bash scripts/smoke_test.sh
 
 ---
 
+## FAQ
+
+**Q: I ran `olw compile` but nothing appears in Obsidian.**
+
+Drafts land in `wiki/.drafts/` — Obsidian hides dotfolders by default so they won't show in the graph yet. Run:
+
+```bash
+olw approve --all
+```
+
+Articles move to `wiki/` and become fully visible. Open `~/my-wiki` as an Obsidian vault (**File → Open vault**) if you haven't already.
+
+---
+
+**Q: Compile says "2 article(s) failed: Methodology, Sprints" — what do I do?**
+
+Failed concepts are not recorded in the DB, so simply re-running compile retries them automatically:
+
+```bash
+olw compile
+```
+
+If the same concepts keep failing, the LLM is likely struggling with JSON output for those specific titles. Try:
+
+```bash
+# More room for the model to produce clean output
+# Edit wiki.toml: heavy_ctx = 32768, then:
+olw compile
+```
+
+See [Tuning context windows](#tuning-context-windows) for the `heavy_ctx` table.
+
+---
+
+**Q: I see `structured_output attempt N failed` messages during compile — is something broken?**
+
+No. This is the built-in 3-tier retry system working as designed. The model occasionally echoes the JSON schema structure instead of flat output — the retry corrects it. Articles are still generated. These messages are debug-level noise; a real failure surfaces as `article(s) failed: ...` in the summary line.
+
+---
+
+**Q: `olw ingest --all && olw compile` gives "Missing option '--vault'".**
+
+Run `olw setup` first to configure a default vault, or pass it explicitly:
+
+```bash
+export OLW_VAULT=~/my-wiki
+olw ingest --all && olw compile
+```
+
+---
+
+**Q: I changed models in `olw setup` but `olw compile` still uses the old model.**
+
+Re-run `olw init` on your vault — it now syncs the model settings from your global config into `wiki.toml`:
+
+```bash
+olw init ~/my-wiki
+```
+
+---
+
 ## Why not just use a chatbot?
 
 Chatbots forget. Every conversation starts fresh. This tool builds a **persistent artifact** — a wiki that grows with every note you add, that you can open in Obsidian, search, query, and edit by hand.

--- a/install.py
+++ b/install.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+install.py — Bootstrap installer for obsidian-llm-wiki (olw).
+
+Usage:
+    python install.py           # auto-detect uv (preferred) or pip
+    python install.py --pip     # force pip install -e .
+    python install.py --uv      # force uv tool install .
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+# ── Color helpers (stdlib only, no deps) ──────────────────────────────────────
+
+
+def _windows_ansi_enabled() -> bool:
+    """Enable VT processing on Windows 10+ and return True if successful."""
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        # ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004, combined with default 0x0003
+        kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+        return True
+    except Exception:
+        return False
+
+
+USE_COLOR = sys.stdout.isatty() and (os.name != "nt" or _windows_ansi_enabled())
+
+
+def _c(text: str, code: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if USE_COLOR else text
+
+
+def green(t: str) -> str:
+    return _c(t, "32")
+
+
+def yellow(t: str) -> str:
+    return _c(t, "33")
+
+
+def red(t: str) -> str:
+    return _c(t, "31")
+
+
+def bold(t: str) -> str:
+    return _c(t, "1")
+
+
+def dim(t: str) -> str:
+    return _c(t, "2")
+
+
+def info(msg: str) -> None:
+    print(f"  {msg}")
+
+
+def ok(msg: str) -> None:
+    print(f"  {green('✓')} {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"  {yellow('!')} {msg}")
+
+
+def err(msg: str) -> None:
+    print(f"  {red('✗')} {msg}", file=sys.stderr)
+
+
+def die(msg: str, code: int = 1) -> None:
+    err(msg)
+    sys.exit(code)
+
+
+def rule(char: str = "─", width: int = 50) -> None:
+    print(dim(char * width))
+
+
+# ── Preflight checks ──────────────────────────────────────────────────────────
+
+
+def check_python() -> None:
+    major, minor = sys.version_info[:2]
+    if (major, minor) < (3, 11):
+        die(
+            f"Python 3.11+ required. You have {major}.{minor}.\n"
+            "  Download from https://python.org/downloads/"
+        )
+    ok(f"Python {major}.{minor}")
+
+
+def check_ollama() -> None:
+    """Non-fatal: warns if ollama binary not found."""
+    if shutil.which("ollama"):
+        ok("ollama found")
+    else:
+        warn("ollama not found — install from https://ollama.com/download")
+        warn("You can install it later; olw will work once ollama is running.")
+
+
+def detect_repo_root() -> Path:
+    here = Path(__file__).parent.resolve()
+    if not (here / "pyproject.toml").exists():
+        die(
+            "Run install.py from the repo root directory (where pyproject.toml lives).\n"
+            f"  Current directory: {here}"
+        )
+    return here
+
+
+# ── Installation ──────────────────────────────────────────────────────────────
+
+
+def detect_installer(force_uv: bool, force_pip: bool) -> str:
+    if force_pip:
+        return "pip"
+    if force_uv:
+        if not shutil.which("uv"):
+            die("uv not found. Install from https://docs.astral.sh/uv/ or use: python install.py --pip")
+        return "uv"
+    return "uv" if shutil.which("uv") else "pip"
+
+
+def install_with_uv(repo_root: Path) -> None:
+    info("Running: uv tool install . --force")
+    result = subprocess.run(["uv", "tool", "install", ".", "--force"], cwd=repo_root)
+    if result.returncode != 0:
+        die("uv install failed. Try: python install.py --pip")
+
+
+def install_with_pip(repo_root: Path) -> None:
+    info("Running: pip install -e .")
+    result = subprocess.run([sys.executable, "-m", "pip", "install", "-e", "."], cwd=repo_root)
+    if result.returncode != 0:
+        die("pip install failed. See errors above.")
+
+
+# ── Verification ──────────────────────────────────────────────────────────────
+
+
+def verify_install() -> bool:
+    """Check that `olw` is on PATH and responds to --version."""
+    olw = shutil.which("olw")
+    if not olw:
+        return False
+    result = subprocess.run(["olw", "--version"], capture_output=True, text=True)
+    return result.returncode == 0
+
+
+def fix_windows_path_hint(installer: str) -> None:
+    """On Windows, print the exact directory to add to PATH."""
+    if os.name != "nt":
+        return
+    if installer == "uv":
+        tools_dir = "~\\.local\\bin"
+        try:
+            r = subprocess.run(["uv", "tool", "dir"], capture_output=True, text=True)
+            if r.returncode == 0:
+                tools_dir = r.stdout.strip()
+        except Exception:
+            pass
+        warn(f"Add to PATH: {tools_dir}")
+        warn("In PowerShell:  $env:PATH += ';' + (uv tool dir)")
+        warn("Permanently:    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, 'User')")
+    else:
+        scripts = Path(sys.prefix) / "Scripts"
+        warn(f"Add to PATH: {scripts}")
+        warn(f"Or run directly: {scripts / 'olw.exe'}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Install obsidian-llm-wiki (olw)")
+    parser.add_argument("--pip", action="store_true", help="Force pip install")
+    parser.add_argument("--uv", action="store_true", help="Force uv install")
+    args = parser.parse_args()
+
+    print()
+    print(bold("obsidian-llm-wiki") + "  installer")
+    rule()
+    print()
+
+    check_python()
+    repo_root = detect_repo_root()
+    check_ollama()
+
+    installer = detect_installer(force_uv=args.uv, force_pip=args.pip)
+    info(f"Package manager: {bold(installer)}")
+    print()
+
+    if installer == "uv":
+        install_with_uv(repo_root)
+    else:
+        install_with_pip(repo_root)
+
+    print()
+
+    if verify_install():
+        ok(f"olw is on PATH and working")
+        print()
+        rule("━")
+        print()
+        ok(bold("Installation complete!"))
+        print()
+        info("Run the interactive setup wizard:")
+        print()
+        print(f"    {bold('olw setup')}")
+        print()
+        info("This configures your Ollama URL, models, and default vault.")
+        print()
+    else:
+        warn("olw was installed but not found on PATH.")
+        fix_windows_path_hint(installer)
+        print()
+        info("After updating PATH, run:")
+        print(f"    {bold('olw setup')}")
+        print()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/install.py
+++ b/install.py
@@ -17,19 +17,18 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 # ── Color helpers (stdlib only, no deps) ──────────────────────────────────────
 
 
 def _windows_ansi_enabled() -> bool:
-    """Enable VT processing on Windows 10+ and return True if successful."""
+    """Enable VT processing on Windows 10+ and return True only if SetConsoleMode succeeds."""
     try:
         import ctypes
 
         kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        stdout = kernel32.GetStdHandle(-11)
         # ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004, combined with default 0x0003
-        kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
-        return True
+        return kernel32.SetConsoleMode(stdout, 7) != 0
     except Exception:
         return False
 
@@ -126,7 +125,10 @@ def detect_installer(force_uv: bool, force_pip: bool) -> str:
         return "pip"
     if force_uv:
         if not shutil.which("uv"):
-            die("uv not found. Install from https://docs.astral.sh/uv/ or use: python install.py --pip")
+            die(
+                "uv not found. Install from https://docs.astral.sh/uv/ "
+                "or use: python install.py --pip"
+            )
         return "uv"
     return "uv" if shutil.which("uv") else "pip"
 
@@ -208,7 +210,7 @@ def main() -> None:
     print()
 
     if verify_install():
-        ok(f"olw is on PATH and working")
+        ok("olw is on PATH and working")
         print()
         rule("━")
         print()

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -380,10 +380,11 @@ conn.execute("""
 conn.commit()
 conn.close()
 PYEOF
-RETRY_OUT=$($OLW compile --retry-failed 2>&1 || true)
-echo "$RETRY_OUT"
+RETRY_TMP=$(mktemp)
+$OLW compile --retry-failed 2>&1 | tee "$RETRY_TMP" || true
 check "retry-failed reports failed notes" \
-    "echo \"$RETRY_OUT\" | grep -qi 'retry\|failed\|not found\|re-ingest'"
+    "grep -qi 'retry\|failed\|not found\|re-ingest' '$RETRY_TMP'"
+rm -f "$RETRY_TMP"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 header "Results"

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -100,22 +100,22 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     else:
         _init_fresh(vault)
 
-    # Write wiki.toml — pre-fill from global config if available
+    # Write or sync wiki.toml from global config
     toml_path = vault / "wiki.toml"
-    if not toml_path.exists():
-        from .config import default_wiki_toml
-        from .global_config import load_global_config
+    from .config import default_wiki_toml
+    from .global_config import load_global_config
 
-        gcfg = load_global_config()
-        toml_path.write_text(
-            default_wiki_toml(
-                fast_model=gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b",
-                heavy_model=gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b",
-                ollama_url=gcfg.ollama_url
-                if gcfg and gcfg.ollama_url
-                else "http://localhost:11434",
-            )
-        )
+    gcfg = load_global_config()
+    fast = gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b"
+    heavy = gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b"
+    ollama_url = gcfg.ollama_url if gcfg and gcfg.ollama_url else "http://localhost:11434"
+
+    if not toml_path.exists():
+        toml_path.write_text(default_wiki_toml(fast, heavy, ollama_url))
+    else:
+        # Existing vault: patch model/URL fields from global config so that
+        # olw setup changes are reflected without overwriting pipeline settings.
+        _sync_wiki_toml_models(toml_path, fast, heavy, ollama_url)
 
     # Init git
     git_init(vault)
@@ -131,6 +131,35 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     console.print("  2. Run [bold]olw ingest --all[/bold]")
     console.print("  3. Run [bold]olw compile[/bold]")
     console.print("  4. Run [bold]olw approve --all[/bold]")
+
+
+def _sync_wiki_toml_models(toml_path: Path, fast: str, heavy: str, ollama_url: str) -> None:
+    """Patch fast/heavy model and Ollama URL in an existing wiki.toml in-place.
+
+    Preserves all other settings (pipeline, rag, etc.) so user customisations
+    are not lost. Only updates fields that come from global config.
+    """
+    import re
+
+    text = toml_path.read_text(encoding="utf-8")
+    original = text
+
+    def _replace_value(t: str, key: str, value: str) -> str:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return re.sub(
+            rf'^({re.escape(key)}\s*=\s*)".+"',
+            rf'\g<1>"{escaped}"',
+            t,
+            flags=re.MULTILINE,
+        )
+
+    text = _replace_value(text, "fast", fast)
+    text = _replace_value(text, "heavy", heavy)
+    text = _replace_value(text, "url", ollama_url)
+
+    if text != original:
+        toml_path.write_text(text, encoding="utf-8")
+        console.print(f"[dim]wiki.toml updated: fast={fast}, heavy={heavy}, url={ollama_url}[/dim]")
 
 
 def _init_fresh(vault: Path) -> None:

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -21,7 +21,9 @@ from pathlib import Path
 
 import click
 from rich.console import Console
+from rich.panel import Panel
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.prompt import Prompt
 from rich.table import Table
 
 console = Console()
@@ -33,9 +35,17 @@ err_console = Console(stderr=True, style="bold red")
 
 def _load_config(vault_str: str | None, **kwargs):
     from .config import Config
+    from .global_config import load_global_config
 
     if not vault_str:
-        click.echo("Error: --vault required (or set OLW_VAULT env var)", err=True)
+        gcfg = load_global_config()
+        vault_str = gcfg.vault if gcfg and gcfg.vault else None
+
+    if not vault_str:
+        click.echo(
+            "Error: no vault specified. Use --vault, set OLW_VAULT, or run `olw setup`.",
+            err=True,
+        )
         sys.exit(1)
     return Config.from_vault(Path(vault_str), **kwargs)
 
@@ -65,7 +75,10 @@ def _load_deps(config):
 @click.group()
 @click.version_option(package_name="obsidian-llm-wiki")
 def cli():
-    """obsidian-llm-wiki (olw) — 100% local Obsidian → wiki pipeline."""
+    """obsidian-llm-wiki (olw) — 100% local Obsidian → wiki pipeline.
+
+    Run `olw setup` for interactive configuration.
+    """
 
 
 # ── init ──────────────────────────────────────────────────────────────────────
@@ -77,7 +90,6 @@ def cli():
 @click.option("--non-interactive", is_flag=True)
 def init(vault_path: str, existing: bool, non_interactive: bool):
     """Create vault structure and initialise olw."""
-    from .config import DEFAULT_WIKI_TOML
     from .git_ops import git_init
 
     vault = Path(vault_path).expanduser().resolve()
@@ -88,10 +100,20 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     else:
         _init_fresh(vault)
 
-    # Write wiki.toml
+    # Write wiki.toml — pre-fill from global config if available
     toml_path = vault / "wiki.toml"
     if not toml_path.exists():
-        toml_path.write_text(DEFAULT_WIKI_TOML)
+        from .config import default_wiki_toml
+        from .global_config import load_global_config
+
+        gcfg = load_global_config()
+        toml_path.write_text(
+            default_wiki_toml(
+                fast_model=gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b",
+                heavy_model=gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b",
+                ollama_url=gcfg.ollama_url if gcfg and gcfg.ollama_url else "http://localhost:11434",
+            )
+        )
 
     # Init git
     git_init(vault)
@@ -158,6 +180,178 @@ def _write_index(vault: Path) -> None:
             "---\ntitle: Index\ntags: [index]\nstatus: published\n---\n\n"
             "# Wiki Index\n\n_Updated automatically by olw._\n"
         )
+
+
+# ── setup ─────────────────────────────────────────────────────────────────────
+
+
+def _pick_model(
+    console: Console,
+    client,
+    step_label: str,
+    description: str,
+    default_fallback: str,
+    connected: bool,
+) -> str:
+    """Interactive model selector — shows table if models available, else free-text."""
+    console.print()
+    console.print(f"  [bold]{step_label}[/bold]  {description}")
+
+    models: list[dict] = []
+    if connected:
+        models = client.list_models_detailed()
+
+    if models:
+        table = Table(show_header=True, box=None, padding=(0, 2))
+        table.add_column("#", style="dim", width=3)
+        table.add_column("Model")
+        table.add_column("Size", style="dim")
+        for i, m in enumerate(models, 1):
+            table.add_row(str(i), m["name"], m["size_gb"])
+        console.print(table)
+        console.print()
+        raw = Prompt.ask("    Select (number or name)", default="1", console=console)
+        if raw.isdigit():
+            idx = int(raw) - 1
+            if 0 <= idx < len(models):
+                return models[idx]["name"]
+            console.print(f"    [yellow]Invalid number, using {default_fallback}[/yellow]")
+            return default_fallback
+        return raw
+    else:
+        if connected:
+            console.print(
+                "    [yellow]No models found.[/yellow] "
+                "Pull one first: [bold]ollama pull gemma4:e4b[/bold]"
+            )
+        console.print("    (e.g. gemma4:e4b, llama3.2:3b, qwen2.5:14b)")
+        return Prompt.ask("    Model name", default=default_fallback, console=console)
+
+
+@cli.command()
+@click.option("--non-interactive", is_flag=True, help="Print current config and exit")
+@click.option("--reset", is_flag=True, help="Clear saved config and re-run wizard")
+def setup(non_interactive: bool, reset: bool):
+    """Interactive wizard: configure Ollama URL, models, and default vault."""
+    from .global_config import GlobalConfig, load_global_config, save_global_config
+    from .ollama_client import OllamaClient
+
+    # ── non-interactive: show current config ──────────────────────────────────
+    if non_interactive:
+        gcfg = load_global_config()
+        if not gcfg:
+            console.print("[dim]No global config found. Run [bold]olw setup[/bold] to configure.[/dim]")
+            return
+        table = Table(title="Global config", show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="bold")
+        table.add_column("Value")
+        table.add_row("Fast model", gcfg.fast_model or "[dim]not set[/dim]")
+        table.add_row("Heavy model", gcfg.heavy_model or "[dim]not set[/dim]")
+        table.add_row("Ollama URL", gcfg.ollama_url or "[dim]not set[/dim]")
+        table.add_row("Default vault", gcfg.vault or "[dim]not set[/dim]")
+        console.print(table)
+        return
+
+    # ── reset: wipe config before wizard ─────────────────────────────────────
+    if reset:
+        save_global_config(GlobalConfig())
+        console.print("[dim]Config cleared.[/dim]")
+
+    try:
+        # ── Header ───────────────────────────────────────────────────────────
+        console.print()
+        console.print(
+            Panel(
+                "[bold]obsidian-llm-wiki[/bold]  ·  first run setup",
+                expand=False,
+                border_style="blue",
+                padding=(0, 4),
+            )
+        )
+        console.print()
+
+        # ── Step 1/4 — Ollama connection ──────────────────────────────────────
+        DEFAULT_URL = "http://localhost:11434"
+        console.print("  [bold]Step 1/4[/bold]  Ollama connection")
+
+        client = OllamaClient(base_url=DEFAULT_URL, timeout=5)
+        connected = client.healthcheck()
+
+        if connected:
+            console.print(f"    Trying {DEFAULT_URL} …  [green]✓ connected[/green]")
+        else:
+            console.print(f"    [yellow]Warning:[/yellow] Could not reach {DEFAULT_URL}")
+            console.print("    You can still configure manually — run [bold]olw doctor[/bold] later.")
+
+        ollama_url = Prompt.ask("    Ollama URL", default=DEFAULT_URL, console=console)
+
+        if ollama_url != DEFAULT_URL:
+            client = OllamaClient(base_url=ollama_url, timeout=5)
+            connected = client.healthcheck()
+            if not connected:
+                console.print(
+                    f"    [yellow]Warning:[/yellow] Cannot reach {ollama_url} — continuing anyway."
+                )
+
+        # ── Step 2/4 — Fast model ─────────────────────────────────────────────
+        fast_model = _pick_model(
+            console=console,
+            client=client,
+            step_label="Step 2/4",
+            description="Fast model  [dim](analysis & routing · 3–8B recommended)[/dim]",
+            default_fallback="gemma4:e4b",
+            connected=connected,
+        )
+
+        # ── Step 3/4 — Heavy model ────────────────────────────────────────────
+        heavy_model = _pick_model(
+            console=console,
+            client=client,
+            step_label="Step 3/4",
+            description="Heavy model  [dim](article writing · 7–14B recommended)[/dim]",
+            default_fallback="qwen2.5:14b",
+            connected=connected,
+        )
+
+        # ── Step 4/4 — Default vault ──────────────────────────────────────────
+        console.print()
+        console.print("  [bold]Step 4/4[/bold]  Default vault path  [dim](press Enter to skip)[/dim]")
+        vault_input = Prompt.ask("    Vault path", default="", console=console)
+        vault_path: str | None = None
+        if vault_input.strip():
+            vault_path = str(Path(vault_input).expanduser().resolve())
+
+        # ── Save ──────────────────────────────────────────────────────────────
+        cfg = GlobalConfig(
+            vault=vault_path,
+            ollama_url=ollama_url,
+            fast_model=fast_model,
+            heavy_model=heavy_model,
+        )
+        save_global_config(cfg)
+
+        # ── Summary panel ─────────────────────────────────────────────────────
+        init_target = vault_path or "~/my-wiki"
+        summary_lines = [
+            "[green]✓[/green]  Setup complete\n",
+            f"  Fast model:   [bold]{fast_model}[/bold]",
+            f"  Heavy model:  [bold]{heavy_model}[/bold]",
+            f"  Ollama:       {ollama_url}",
+        ]
+        if vault_path:
+            summary_lines.append(f"  Vault:        {vault_path}")
+        summary_lines += [
+            "",
+            "  Next steps:",
+            f"    [bold]olw init {init_target}[/bold]",
+            "    [bold]olw ingest --all && olw compile[/bold]",
+        ]
+        console.print()
+        console.print(Panel("\n".join(summary_lines), border_style="green", expand=False, padding=(0, 2)))
+
+    except (EOFError, KeyboardInterrupt):
+        console.print("\n[yellow]Setup interrupted.[/yellow]")
+        sys.exit(1)
 
 
 # ── ingest ────────────────────────────────────────────────────────────────────

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -111,7 +111,9 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
             default_wiki_toml(
                 fast_model=gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b",
                 heavy_model=gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b",
-                ollama_url=gcfg.ollama_url if gcfg and gcfg.ollama_url else "http://localhost:11434",
+                ollama_url=gcfg.ollama_url
+                if gcfg and gcfg.ollama_url
+                else "http://localhost:11434",
             )
         )
 
@@ -240,7 +242,9 @@ def setup(non_interactive: bool, reset: bool):
     if non_interactive:
         gcfg = load_global_config()
         if not gcfg:
-            console.print("[dim]No global config found. Run [bold]olw setup[/bold] to configure.[/dim]")
+            console.print(
+                "[dim]No global config found. Run [bold]olw setup[/bold] to configure.[/dim]"
+            )
             return
         table = Table(title="Global config", show_header=False, box=None, padding=(0, 2))
         table.add_column("Key", style="bold")
@@ -281,7 +285,9 @@ def setup(non_interactive: bool, reset: bool):
             console.print(f"    Trying {DEFAULT_URL} …  [green]✓ connected[/green]")
         else:
             console.print(f"    [yellow]Warning:[/yellow] Could not reach {DEFAULT_URL}")
-            console.print("    You can still configure manually — run [bold]olw doctor[/bold] later.")
+            console.print(
+                "    You can still configure manually — run [bold]olw doctor[/bold] later."
+            )
 
         ollama_url = Prompt.ask("    Ollama URL", default=DEFAULT_URL, console=console)
 
@@ -315,7 +321,9 @@ def setup(non_interactive: bool, reset: bool):
 
         # ── Step 4/4 — Default vault ──────────────────────────────────────────
         console.print()
-        console.print("  [bold]Step 4/4[/bold]  Default vault path  [dim](press Enter to skip)[/dim]")
+        console.print(
+            "  [bold]Step 4/4[/bold]  Default vault path  [dim](press Enter to skip)[/dim]"
+        )
         vault_input = Prompt.ask("    Vault path", default="", console=console)
         vault_path: str | None = None
         if vault_input.strip():
@@ -347,7 +355,9 @@ def setup(non_interactive: bool, reset: bool):
             "    [bold]olw ingest --all && olw compile[/bold]",
         ]
         console.print()
-        console.print(Panel("\n".join(summary_lines), border_style="green", expand=False, padding=(0, 2)))
+        console.print(
+            Panel("\n".join(summary_lines), border_style="green", expand=False, padding=(0, 2))
+        )
 
     except (EOFError, KeyboardInterrupt):
         console.print("\n[yellow]Setup interrupted.[/yellow]")

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -37,7 +37,7 @@ def _load_config(vault_str: str | None, **kwargs):
     from .config import Config
     from .global_config import load_global_config
 
-    if not vault_str:
+    if vault_str is None:
         gcfg = load_global_config()
         vault_str = gcfg.vault if gcfg and gcfg.vault else None
 
@@ -241,7 +241,9 @@ def _pick_model(
             table.add_row(str(i), m["name"], m["size_gb"])
         console.print(table)
         console.print()
-        raw = Prompt.ask("    Select (number or name)", default="1", console=console)
+        raw = Prompt.ask("    Select (number or name)", default="1", console=console).strip()
+        if not raw:
+            return default_fallback
         if raw.isdigit():
             idx = int(raw) - 1
             if 0 <= idx < len(models):
@@ -256,7 +258,8 @@ def _pick_model(
                 "Pull one first: [bold]ollama pull gemma4:e4b[/bold]"
             )
         console.print("    (e.g. gemma4:e4b, llama3.2:3b, qwen2.5:14b)")
-        return Prompt.ask("    Model name", default=default_fallback, console=console)
+        raw = Prompt.ask("    Model name", default=default_fallback, console=console).strip()
+        return raw if raw else default_fallback
 
 
 @cli.command()

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -358,7 +358,7 @@ def setup(non_interactive: bool, reset: bool):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--all", "ingest_all", is_flag=True, help="Ingest all files in raw/")
 @click.option("--force", is_flag=True, help="Re-ingest already-processed notes")
 @click.argument("paths", nargs=-1, type=click.Path(exists=True))
@@ -445,7 +445,7 @@ def ingest(vault_str, ingest_all, force, paths):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--dry-run", is_flag=True, help="Show plan, write nothing")
 @click.option("--auto-approve", is_flag=True, help="Publish immediately (skip draft review)")
 @click.option("--force", is_flag=True, help="Recompile even manually-edited articles")
@@ -561,7 +561,7 @@ def compile(vault_str, dry_run, auto_approve, force, legacy, retry_failed):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--all", "approve_all", is_flag=True)
 @click.argument("files", nargs=-1, type=click.Path())
 def approve(vault_str, approve_all, files):
@@ -604,7 +604,7 @@ def approve(vault_str, approve_all, files):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--feedback", default="", help="Reason for rejection (logged)")
 @click.argument("file", type=click.Path(exists=True))
 def reject(vault_str, feedback, file):
@@ -621,7 +621,7 @@ def reject(vault_str, feedback, file):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--failed", "show_failed", is_flag=True, help="List failed notes with error messages")
 def status(vault_str, show_failed):
     """Show vault health, pending drafts, and pipeline stats."""
@@ -669,7 +669,7 @@ def status(vault_str, show_failed):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--steps", default=1, show_default=True)
 def undo(vault_str, steps):
     """Revert last N [olw] auto-commits (uses git revert — safe)."""
@@ -689,7 +689,7 @@ def undo(vault_str, steps):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--yes", is_flag=True, help="Skip confirmation prompt")
 def clean(vault_str, yes):
     """Clear state DB, wiki/, and drafts — raw/ notes are kept.
@@ -734,7 +734,7 @@ def clean(vault_str, yes):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 def doctor(vault_str):
     """Check Ollama connection, model availability, and vault health."""
     from .ollama_client import OllamaClient, OllamaError
@@ -817,7 +817,7 @@ def doctor(vault_str):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--save", is_flag=True, help="Save answer to wiki/queries/")
 @click.argument("question")
 def query(vault_str, question, save):
@@ -844,7 +844,7 @@ def query(vault_str, question, save):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option("--fix", is_flag=True, help="Auto-fix simple issues (missing frontmatter fields)")
 def lint(vault_str, fix):
     """Check wiki health: orphans, broken links, missing frontmatter, low confidence."""
@@ -887,7 +887,7 @@ def lint(vault_str, fix):
 
 
 @cli.command()
-@click.option("--vault", "vault_str", envvar="OLW_VAULT", required=True)
+@click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 @click.option(
     "--auto-approve", is_flag=True, help="Publish drafts immediately without manual review"
 )

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -25,6 +25,12 @@ max_concepts_per_source = 8
 """
 
 
+def _toml_quote(value: str) -> str:
+    """Return a safely quoted TOML basic string, escaping backslashes and double quotes."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def default_wiki_toml(
     fast_model: str = "gemma4:e4b",
     heavy_model: str = "qwen2.5:14b",
@@ -32,20 +38,20 @@ def default_wiki_toml(
 ) -> str:
     """Generate wiki.toml content, optionally pre-filled from global config."""
     return (
-        f'[models]\n'
-        f'fast = "{fast_model}"\n'
-        f'heavy = "{heavy_model}"\n'
-        f'# Optional: set heavy = fast to use a single model for everything\n\n'
-        f'[ollama]\n'
-        f'url = "{ollama_url}"\n'
-        f'timeout = 600\n'
-        f'fast_ctx = 8192\n'
-        f'heavy_ctx = 16384\n\n'
-        f'[pipeline]\n'
-        f'auto_approve = false\n'
-        f'auto_commit = true\n'
-        f'watch_debounce = 3.0\n'
-        f'max_concepts_per_source = 8\n'
+        f"[models]\n"
+        f"fast = {_toml_quote(fast_model)}\n"
+        f"heavy = {_toml_quote(heavy_model)}\n"
+        f"# Optional: set heavy = fast to use a single model for everything\n\n"
+        f"[ollama]\n"
+        f"url = {_toml_quote(ollama_url)}\n"
+        f"timeout = 600\n"
+        f"fast_ctx = 8192\n"
+        f"heavy_ctx = 16384\n\n"
+        f"[pipeline]\n"
+        f"auto_approve = false\n"
+        f"auto_commit = true\n"
+        f"watch_debounce = 3.0\n"
+        f"max_concepts_per_source = 8\n"
     )
 
 

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -25,6 +25,30 @@ max_concepts_per_source = 8
 """
 
 
+def default_wiki_toml(
+    fast_model: str = "gemma4:e4b",
+    heavy_model: str = "qwen2.5:14b",
+    ollama_url: str = "http://localhost:11434",
+) -> str:
+    """Generate wiki.toml content, optionally pre-filled from global config."""
+    return (
+        f'[models]\n'
+        f'fast = "{fast_model}"\n'
+        f'heavy = "{heavy_model}"\n'
+        f'# Optional: set heavy = fast to use a single model for everything\n\n'
+        f'[ollama]\n'
+        f'url = "{ollama_url}"\n'
+        f'timeout = 600\n'
+        f'fast_ctx = 8192\n'
+        f'heavy_ctx = 16384\n\n'
+        f'[pipeline]\n'
+        f'auto_approve = false\n'
+        f'auto_commit = true\n'
+        f'watch_debounce = 3.0\n'
+        f'max_concepts_per_source = 8\n'
+    )
+
+
 class ModelsConfig(BaseModel):
     fast: str = "gemma4:e4b"
     heavy: str = "qwen2.5:14b"

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -5,29 +5,16 @@ from pathlib import Path
 
 from pydantic import BaseModel, field_validator
 
-DEFAULT_WIKI_TOML = """\
-[models]
-fast = "gemma4:e4b"
-heavy = "qwen2.5:14b"
-# Optional: set heavy = fast to use a single model for everything
-
-[ollama]
-url = "http://localhost:11434"
-timeout = 600
-fast_ctx = 8192
-heavy_ctx = 16384
-
-[pipeline]
-auto_approve = false
-auto_commit = true
-watch_debounce = 3.0
-max_concepts_per_source = 8
-"""
-
 
 def _toml_quote(value: str) -> str:
-    """Return a safely quoted TOML basic string, escaping backslashes and double quotes."""
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    """Return a safely quoted TOML basic string, escaping backslashes, quotes, and control chars."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
     return f'"{escaped}"'
 
 

--- a/src/obsidian_llm_wiki/global_config.py
+++ b/src/obsidian_llm_wiki/global_config.py
@@ -1,0 +1,68 @@
+"""
+Global user-level config for olw, stored at:
+  - Mac/Linux: ~/.config/olw/config.toml  (or $XDG_CONFIG_HOME/olw/config.toml)
+  - Windows:   %%APPDATA%%\\olw\\config.toml
+
+This is separate from the per-vault wiki.toml. It stores user preferences
+(default vault, Ollama URL, model choices) so commands work without --vault.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GlobalConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    vault: str | None = None
+    ollama_url: str | None = None
+    fast_model: str | None = None
+    heavy_model: str | None = None
+
+
+def _global_config_path() -> Path:
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "olw" / "config.toml"
+    xdg = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(xdg) / "olw" / "config.toml"
+
+
+def load_global_config() -> GlobalConfig | None:
+    """Load global config. Returns None if missing or malformed — never raises."""
+    path = _global_config_path()
+    if not path.exists():
+        return None
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        return GlobalConfig(**data)
+    except Exception:
+        return None
+
+
+def save_global_config(cfg: GlobalConfig) -> None:
+    """Write global config to disk. Creates parent directory if needed."""
+    path = _global_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if cfg.vault is not None:
+        lines.append(f"vault = {_toml_str(cfg.vault)}")
+    if cfg.ollama_url is not None:
+        lines.append(f"ollama_url = {_toml_str(cfg.ollama_url)}")
+    if cfg.fast_model is not None:
+        lines.append(f"fast_model = {_toml_str(cfg.fast_model)}")
+    if cfg.heavy_model is not None:
+        lines.append(f"heavy_model = {_toml_str(cfg.heavy_model)}")
+    path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+
+
+def _toml_str(value: str) -> str:
+    """Minimal safe TOML string quoting — escapes backslashes and double quotes."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'

--- a/src/obsidian_llm_wiki/global_config.py
+++ b/src/obsidian_llm_wiki/global_config.py
@@ -63,6 +63,12 @@ def save_global_config(cfg: GlobalConfig) -> None:
 
 
 def _toml_str(value: str) -> str:
-    """Minimal safe TOML string quoting — escapes backslashes and double quotes."""
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    """Minimal safe TOML string quoting — escapes backslashes, double quotes, and control chars."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
     return f'"{escaped}"'

--- a/src/obsidian_llm_wiki/ollama_client.py
+++ b/src/obsidian_llm_wiki/ollama_client.py
@@ -52,6 +52,22 @@ class OllamaClient:
         resp.raise_for_status()
         return [m["name"] for m in resp.json().get("models", [])]
 
+    def list_models_detailed(self) -> list[dict]:
+        """Return list of {'name': str, 'size_gb': str} for the setup wizard table."""
+        try:
+            resp = self._client.get(f"{self.base_url}/api/tags")
+            resp.raise_for_status()
+            models = resp.json().get("models", [])
+            return [
+                {
+                    "name": m["name"],
+                    "size_gb": f"{m.get('size', 0) / 1e9:.1f} GB",
+                }
+                for m in models
+            ]
+        except Exception:
+            return []
+
     def pull_model(self, model: str) -> None:
         """Pull model if not present. Streams progress to stderr."""
         import sys

--- a/src/obsidian_llm_wiki/ollama_client.py
+++ b/src/obsidian_llm_wiki/ollama_client.py
@@ -65,7 +65,7 @@ class OllamaClient:
                 }
                 for m in models
             ]
-        except Exception:
+        except (httpx.HTTPError, KeyError, ValueError):
             return []
 
     def pull_model(self, model: str) -> None:

--- a/src/obsidian_llm_wiki/structured_output.py
+++ b/src/obsidian_llm_wiki/structured_output.py
@@ -176,7 +176,7 @@ def request_structured(
         except json.JSONDecodeError as e:
             last_error = f"Invalid JSON: {e}"
 
-        log.warning(
+        log.debug(
             "structured_output attempt %d failed: %s. Raw (first 300): %s",
             attempt + 1,
             last_error,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -5,8 +5,6 @@ All tests are offline — no Ollama instance required.
 
 from __future__ import annotations
 
-import os
-import sys
 import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,7 +20,6 @@ from obsidian_llm_wiki.global_config import (
     load_global_config,
     save_global_config,
 )
-
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -57,7 +54,7 @@ def test_toml_str_escapes_quotes():
 
 
 def test_toml_str_combined():
-    result = _toml_str("C:\\path\\to\\my \"wiki\"")
+    result = _toml_str('C:\\path\\to\\my "wiki"')
     assert result == '"C:\\\\path\\\\to\\\\my \\"wiki\\""'
 
 
@@ -145,7 +142,9 @@ def test_load_unknown_fields_returns_none(cfg_dir: Path):
 # ── _load_config fallback ─────────────────────────────────────────────────────
 
 
-def test_load_config_uses_global_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg_dir: Path):
+def test_load_config_uses_global_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg_dir: Path
+):
     """_load_config(None) should fall back to global config vault."""
     vault = tmp_path / "wiki"
     vault.mkdir()
@@ -203,7 +202,7 @@ def test_setup_reset_clears_config(runner: CliRunner, cfg_dir: Path):
     save_global_config(GlobalConfig(fast_model="old-model"))
 
     # Provide all wizard inputs via stdin so it runs non-interactively in tests
-    # Inputs: URL (enter=default), fast model (enter=default), heavy model (enter=default), vault (enter=skip)
+    # Inputs: URL (default), fast model (default), heavy model (default), vault (skip)
     result = runner.invoke(
         cli,
         ["setup", "--reset"],

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -322,3 +322,34 @@ def test_init_defaults_without_global_config(runner: CliRunner, cfg_dir: Path, t
     content = (vault / "wiki.toml").read_text()
     assert "gemma4:e4b" in content
     assert "qwen2.5:14b" in content
+
+
+def test_init_syncs_models_into_existing_wiki_toml(
+    runner: CliRunner, cfg_dir: Path, tmp_path: Path
+):
+    """olw init on an existing vault should patch models from global config."""
+    vault = tmp_path / "existing-vault"
+    vault.mkdir()
+    # Simulate old wiki.toml with stale heavy model
+    old_toml = (
+        '[models]\nfast = "gemma4:e4b"\nheavy = "qwen2.5:14b"\n\n'
+        '[ollama]\nurl = "http://localhost:11434"\ntimeout = 600\n\n'
+        "[pipeline]\nauto_approve = false\nauto_commit = true\n"
+    )
+    (vault / "wiki.toml").write_text(old_toml)
+
+    save_global_config(
+        GlobalConfig(
+            fast_model="gemma4:e4b",
+            heavy_model="gemma4:e4b",
+            ollama_url="http://localhost:11434",
+        )
+    )
+    result = runner.invoke(cli, ["init", str(vault)])
+    assert result.exit_code == 0
+
+    content = (vault / "wiki.toml").read_text()
+    # heavy should now be gemma4:e4b (patched from global config)
+    assert 'heavy = "gemma4:e4b"' in content
+    # pipeline settings must be preserved
+    assert "auto_approve = false" in content

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -58,6 +58,21 @@ def test_toml_str_combined():
     assert result == '"C:\\\\path\\\\to\\\\my \\"wiki\\""'
 
 
+def test_toml_str_escapes_control_chars():
+    assert _toml_str("line1\nline2") == '"line1\\nline2"'
+    assert _toml_str("col1\tcol2") == '"col1\\tcol2"'
+    assert _toml_str("cr\rhere") == '"cr\\rhere"'
+
+
+def test_toml_str_control_chars_produce_valid_toml(cfg_dir: Path):
+    """Paths with control chars must still round-trip through save/load."""
+    cfg = GlobalConfig(fast_model="model\twith\ttabs")
+    save_global_config(cfg)
+    loaded = load_global_config()
+    assert loaded is not None
+    assert loaded.fast_model == "model\twith\ttabs"
+
+
 # ── save / load round-trip ────────────────────────────────────────────────────
 
 
@@ -264,6 +279,30 @@ def test_setup_wizard_model_number_selection(runner: CliRunner, cfg_dir: Path):
     assert cfg is not None
     assert cfg.fast_model == "gemma4:e4b"
     assert cfg.heavy_model == "qwen2.5:14b"
+
+
+def test_setup_wizard_whitespace_input_uses_default(runner: CliRunner, cfg_dir: Path):
+    """Spaces-only model input should fall back to default, not save a blank model name."""
+    with patch("obsidian_llm_wiki.ollama_client.OllamaClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        # Send spaces for fast and heavy model prompts (no table, free-text path)
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            input="\n   \n   \n\n",  # URL default, spaces for fast, spaces for heavy, no vault
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    # Should have fallen back to defaults, not saved empty/whitespace strings
+    assert cfg.fast_model and cfg.fast_model.strip() != ""
+    assert cfg.heavy_model and cfg.heavy_model.strip() != ""
 
 
 def test_setup_wizard_with_vault(runner: CliRunner, cfg_dir: Path, tmp_path: Path):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,325 @@
+"""
+Tests for global_config module and olw setup command.
+All tests are offline — no Ollama instance required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from obsidian_llm_wiki.cli import cli
+from obsidian_llm_wiki.global_config import (
+    GlobalConfig,
+    _global_config_path,
+    _toml_str,
+    load_global_config,
+    save_global_config,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def cfg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect global config to a temp dir."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # On Windows, patch APPDATA too
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── _toml_str ─────────────────────────────────────────────────────────────────
+
+
+def test_toml_str_simple():
+    assert _toml_str("hello") == '"hello"'
+
+
+def test_toml_str_escapes_backslashes():
+    assert _toml_str("C:\\Users\\alex") == '"C:\\\\Users\\\\alex"'
+
+
+def test_toml_str_escapes_quotes():
+    assert _toml_str('say "hi"') == '"say \\"hi\\""'
+
+
+def test_toml_str_combined():
+    result = _toml_str("C:\\path\\to\\my \"wiki\"")
+    assert result == '"C:\\\\path\\\\to\\\\my \\"wiki\\""'
+
+
+# ── save / load round-trip ────────────────────────────────────────────────────
+
+
+def test_save_load_full_config(cfg_dir: Path):
+    cfg = GlobalConfig(
+        vault="/tmp/my-wiki",
+        ollama_url="http://localhost:11434",
+        fast_model="gemma4:e4b",
+        heavy_model="qwen2.5:14b",
+    )
+    save_global_config(cfg)
+    loaded = load_global_config()
+    assert loaded == cfg
+
+
+def test_save_creates_parent_dirs(cfg_dir: Path):
+    cfg = GlobalConfig(fast_model="gemma4:e4b")
+    save_global_config(cfg)
+    path = _global_config_path()
+    assert path.exists()
+    assert path.parent.is_dir()
+
+
+def test_saved_file_is_valid_toml(cfg_dir: Path):
+    cfg = GlobalConfig(
+        vault="/tmp/wiki",
+        fast_model="gemma4:e4b",
+        heavy_model="qwen2.5:14b",
+        ollama_url="http://localhost:11434",
+    )
+    save_global_config(cfg)
+    path = _global_config_path()
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    assert data["fast_model"] == "gemma4:e4b"
+    assert data["heavy_model"] == "qwen2.5:14b"
+
+
+def test_partial_config_no_null_keys(cfg_dir: Path):
+    """None fields must not appear in the written TOML file."""
+    cfg = GlobalConfig(fast_model="gemma4:e4b")
+    save_global_config(cfg)
+    path = _global_config_path()
+    raw = path.read_text()
+    assert "vault" not in raw
+    assert "ollama_url" not in raw
+    assert "heavy_model" not in raw
+    assert "fast_model" in raw
+
+
+def test_empty_config_writes_empty_file(cfg_dir: Path):
+    save_global_config(GlobalConfig())
+    path = _global_config_path()
+    assert path.read_text() == ""
+
+
+# ── load error handling ───────────────────────────────────────────────────────
+
+
+def test_load_missing_file_returns_none(cfg_dir: Path):
+    result = load_global_config()
+    assert result is None
+
+
+def test_load_malformed_toml_returns_none(cfg_dir: Path):
+    path = _global_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("this is not [ valid toml !!!!", encoding="utf-8")
+    result = load_global_config()
+    assert result is None
+
+
+def test_load_unknown_fields_returns_none(cfg_dir: Path):
+    """Extra keys not in GlobalConfig schema should cause load to return None."""
+    path = _global_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('unknown_key = "value"\n', encoding="utf-8")
+    result = load_global_config()
+    assert result is None
+
+
+# ── _load_config fallback ─────────────────────────────────────────────────────
+
+
+def test_load_config_uses_global_vault(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg_dir: Path):
+    """_load_config(None) should fall back to global config vault."""
+    vault = tmp_path / "wiki"
+    vault.mkdir()
+    (vault / "wiki.toml").write_text(
+        '[models]\nfast = "gemma4:e4b"\nheavy = "qwen2.5:14b"\n[ollama]\nurl = "http://localhost:11434"\n'
+    )
+
+    save_global_config(GlobalConfig(vault=str(vault)))
+
+    # Import here to use real _load_config
+    from obsidian_llm_wiki.cli import _load_config
+
+    config = _load_config(None)
+    assert config.vault == vault
+
+
+def test_load_config_no_vault_exits(monkeypatch: pytest.MonkeyPatch, cfg_dir: Path):
+    """_load_config(None) with no global config should sys.exit(1)."""
+    from obsidian_llm_wiki.cli import _load_config
+
+    monkeypatch.delenv("OLW_VAULT", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        _load_config(None)
+    assert exc.value.code == 1
+
+
+# ── olw setup --non-interactive ───────────────────────────────────────────────
+
+
+def test_setup_non_interactive_no_config(runner: CliRunner, cfg_dir: Path):
+    result = runner.invoke(cli, ["setup", "--non-interactive"])
+    assert result.exit_code == 0
+    assert "No global config" in result.output
+
+
+def test_setup_non_interactive_with_config(runner: CliRunner, cfg_dir: Path):
+    save_global_config(
+        GlobalConfig(
+            fast_model="gemma4:e4b",
+            heavy_model="qwen2.5:14b",
+            ollama_url="http://192.168.1.10:11434",
+        )
+    )
+    result = runner.invoke(cli, ["setup", "--non-interactive"])
+    assert result.exit_code == 0
+    assert "gemma4:e4b" in result.output
+    assert "qwen2.5:14b" in result.output
+    assert "192.168.1.10" in result.output
+
+
+# ── olw setup --reset ─────────────────────────────────────────────────────────
+
+
+def test_setup_reset_clears_config(runner: CliRunner, cfg_dir: Path):
+    save_global_config(GlobalConfig(fast_model="old-model"))
+
+    # Provide all wizard inputs via stdin so it runs non-interactively in tests
+    # Inputs: URL (enter=default), fast model (enter=default), heavy model (enter=default), vault (enter=skip)
+    result = runner.invoke(
+        cli,
+        ["setup", "--reset"],
+        input="\n\n\n\n",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    loaded = load_global_config()
+    # After reset + wizard with defaults, old-model should be gone
+    assert loaded is not None
+    assert loaded.fast_model != "old-model"
+
+
+# ── olw setup wizard (stdin input) ───────────────────────────────────────────
+
+
+def test_setup_wizard_saves_config(runner: CliRunner, cfg_dir: Path):
+    """Wizard with all-default inputs should create a valid config."""
+    with patch("obsidian_llm_wiki.ollama_client.OllamaClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            input="\ngemma4:e4b\nqwen2.5:14b\n\n",  # URL default, fast, heavy, no vault
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.fast_model == "gemma4:e4b"
+    assert cfg.heavy_model == "qwen2.5:14b"
+
+
+def test_setup_wizard_model_number_selection(runner: CliRunner, cfg_dir: Path):
+    """Selecting model by number from the list should resolve to model name."""
+    with patch("obsidian_llm_wiki.ollama_client.OllamaClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = True
+        instance.list_models_detailed.return_value = [
+            {"name": "gemma4:e4b", "size_gb": "4.3 GB"},
+            {"name": "qwen2.5:14b", "size_gb": "8.7 GB"},
+        ]
+        MockClient.return_value = instance
+
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            input="\n1\n2\n\n",  # URL default, pick #1 fast, pick #2 heavy, no vault
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.fast_model == "gemma4:e4b"
+    assert cfg.heavy_model == "qwen2.5:14b"
+
+
+def test_setup_wizard_with_vault(runner: CliRunner, cfg_dir: Path, tmp_path: Path):
+    """Setting a vault path in wizard should save it to global config."""
+    vault = tmp_path / "my-wiki"
+
+    with patch("obsidian_llm_wiki.ollama_client.OllamaClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            input=f"\ngemma4:e4b\nqwen2.5:14b\n{vault}\n",
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.vault == str(vault.resolve())
+
+
+# ── olw init uses global config models ───────────────────────────────────────
+
+
+def test_init_uses_global_config_models(runner: CliRunner, cfg_dir: Path, tmp_path: Path):
+    """olw init should pre-fill wiki.toml from global config models."""
+    save_global_config(
+        GlobalConfig(
+            fast_model="llama3.2:3b",
+            heavy_model="llama3.1:8b",
+            ollama_url="http://192.168.1.5:11434",
+        )
+    )
+    vault = tmp_path / "test-vault"
+    result = runner.invoke(cli, ["init", str(vault)])
+    assert result.exit_code == 0
+
+    toml_path = vault / "wiki.toml"
+    assert toml_path.exists()
+    content = toml_path.read_text()
+    assert "llama3.2:3b" in content
+    assert "llama3.1:8b" in content
+    assert "192.168.1.5" in content
+
+
+def test_init_defaults_without_global_config(runner: CliRunner, cfg_dir: Path, tmp_path: Path):
+    """olw init without global config should use built-in defaults."""
+    vault = tmp_path / "test-vault"
+    result = runner.invoke(cli, ["init", str(vault)])
+    assert result.exit_code == 0
+
+    content = (vault / "wiki.toml").read_text()
+    assert "gemma4:e4b" in content
+    assert "qwen2.5:14b" in content


### PR DESCRIPTION
- install.py: cross-platform bootstrapper (uv or pip, ANSI output, Windows PATH hints)
- global_config.py: per-user ~/.config/olw/config.toml (vault, models, Ollama URL)
- olw setup: interactive wizard with Rich panels, model table from live Ollama
- _load_config: falls back to global config vault so --vault flag is optional
- olw init: pre-fills wiki.toml from global config models/URL
- default_wiki_toml(): parameterised version alongside DEFAULT_WIKI_TOML constant
- list_models_detailed(): new OllamaClient method returning name + size for wizard
- 22 new offline tests in tests/test_setup.py (all 139 pass)
- README: updated quick start, gemma3:4b → gemma4:e4b, olw setup in commands table