### PR TITLE
feat: multi-provider support (OpenAI-compatible backends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [0.3.0] - 2026-04-15
+
+### Highlights
+
+**v0.3 opens the pipeline to any LLM provider.** Ollama stays the default, but you can now point `olw` at Groq, Together AI, Mistral, LM Studio, vLLM, Azure OpenAI, or any other OpenAI-compatible endpoint — local or cloud. The setup wizard gained a provider selection step, API keys are stored securely in the global config (never in `wiki.toml`), and all pipeline internals use a shared protocol so adding new providers requires no pipeline changes.
+
+### New Features
+
+- **Multi-provider support** — `olw setup` now presents a numbered provider menu covering 9 local runtimes (LM Studio, vLLM, llama.cpp, LocalAI, TGI, SGLang, Llamafile, Lemonade, Ollama) and 11 cloud providers (Groq, Together AI, Fireworks AI, DeepInfra, OpenRouter, Mistral AI, DeepSeek, SiliconFlow, Perplexity, xAI / Grok, Azure OpenAI) plus a free-form Custom option. Select by number or name.
+
+- **OpenAI-compatible client** (`openai_compat_client.py`) — thin `httpx` wrapper matching the `OllamaClient` interface. Handles bearer auth, Azure `api-key` header + `?api-version=` query param, JSON mode with auto-downgrade on HTTP 400, and ordered embedding responses.
+
+- **`[provider]` section in `wiki.toml`** — non-Ollama vaults use a `[provider]` block with `name`, `url`, `timeout`, `fast_ctx`, `heavy_ctx` (and `azure_api_version` for Azure). The `[ollama]` section still works unchanged — existing vaults need no migration.
+
+- **API key security** — keys are stored in `~/.config/olw/config.toml` (user-private global config) and resolved at runtime from the provider-specific env var (e.g. `GROQ_API_KEY`), the generic `OLW_API_KEY` env var, or the global config `api_key` field. They are never written to `wiki.toml`.
+
+- **`LLMClientProtocol`** — structural interface (`typing.Protocol`) that both `OllamaClient` and `OpenAICompatClient` satisfy. All pipeline stages (`ingest`, `compile`, `query`, `orchestrator`, `structured_output`) now depend on the protocol, not the concrete Ollama class.
+
+- **`build_client()` factory** — resolves the correct client from `config.effective_provider`. Pipelines and tests need no awareness of which provider is active.
+
+### Improvements
+
+- `olw doctor` is now provider-aware: shows the active provider name and URL, and gives provider-appropriate hints for missing models
+- `olw setup` temp client correctly passes `azure=True` and `supports_embeddings` flags so the health probe uses the right auth header
+- Empty URL for `custom` or `azure` provider now exits with a clear error instead of producing cryptic HTTP failures later
+- `azure_api_version` flows from `olw setup` → global config → `wiki.toml` (Azure vaults) so each vault can override the API version independently
+- `embed_batch` now catches `TimeoutException` and wraps it as `LLMError` (previously only `generate` did)
+- `LLMClientProtocol` declares `__enter__`/`__exit__` so type checkers recognise both clients as context managers
+
+### Breaking Changes
+
+None. Ollama remains the default. Existing `wiki.toml` files with `[ollama]` sections work without modification.
+
 ## [0.2.0] - 2026-04-11
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Drop a markdown file into a folder. The pipeline reads it, extracts concepts, and creates or updates wiki articles with the new knowledge. Reject a draft and explain why — the next compile addresses your feedback. Over time your wiki compounds: every note you add (and every draft you review) makes the whole smarter.
 
-**100% local. No cloud, no API keys, no telemetry.** Just [Ollama](https://ollama.com) running on your machine.
+**Local-first, provider-flexible.** Runs 100% locally with [Ollama](https://ollama.com) by default. Also works with any OpenAI-compatible endpoint — Groq, Together AI, LM Studio, vLLM, Azure OpenAI, and [more](#providers).
 
 ---
 
@@ -44,7 +44,8 @@ The wiki lives in Obsidian, so you get the graph view, backlinks, and Dataview q
 - **Wiki health checks** — `olw lint` detects orphans, broken links, stale articles (no LLM needed)
 - **Query your wiki** — `olw query "what is X?"` answers from your published articles
 - **Git safety net** — every auto-action is committed; `olw undo` reverts safely
-- **Offline test suite** — all 322 tests run without Ollama
+- **Multi-provider** — swap Ollama for Groq, Together AI, LM Studio, vLLM, Azure OpenAI, or any OpenAI-compatible endpoint via `olw setup`
+- **Offline test suite** — all 373 tests run without Ollama or any provider
 
 ---
 
@@ -90,17 +91,32 @@ ollama pull qwen2.5:14b     # heavy model — article writing (optional, 7B+ rec
 olw setup
 ```
 
-An interactive wizard configures your Ollama URL, fast and heavy models, and an optional default vault path. Takes ~30 seconds.
+An interactive wizard selects a provider, configures the URL and optional API key, picks fast and heavy models, and sets an optional default vault. Takes ~30 seconds.
 
 ```
 ╭──────────────────────────────────────────────────╮
-│      obsidian-llm-wiki  ·  first run setup       │
+│      obsidian-llm-wiki  ·  setup                 │
 ╰──────────────────────────────────────────────────╯
 
-  Step 1/4  Ollama connection
-    Trying http://localhost:11434 …  ✓ connected
+  Step 1  Provider
 
-  Step 2/4  Fast model (analysis · 3–8B recommended)
+    Local (no API key needed):
+       1. Ollama          http://localhost:11434  [default]
+       2. LM Studio       http://localhost:1234/v1
+       3. vLLM            http://localhost:8000/v1
+       ...
+    Cloud (API key required):
+      10. Groq            https://api.groq.com/openai/v1
+      11. Together AI     https://api.together.xyz/v1
+      ...
+
+    Select provider (number or name) [1]: _
+
+  Step 2  URL
+    Base URL [http://localhost:11434]: _
+    ✓ connected
+
+  Step 3  Fast model  (analysis & routing · 3–8B recommended)
     #  Model           Size
     1  gemma4:e4b      9.6 GB
     2  phi4-mini       2.5 GB
@@ -108,7 +124,7 @@ An interactive wizard configures your Ollama URL, fast and heavy models, and an 
   ...
 ```
 
-Settings are saved to `~/.config/olw/config.toml` (Mac/Linux) or `%APPDATA%\olw\config.toml` (Windows).
+Settings are saved to `~/.config/olw/config.toml` (Mac/Linux) or `%APPDATA%\olw\config.toml` (Windows). API keys are stored only in this user-private file, never in `wiki.toml`.
 
 ### 4. Set up your vault
 
@@ -266,11 +282,21 @@ fast = "gemma4:e4b"        # extraction, analysis, query routing
 heavy = "qwen2.5:14b"     # article generation, Q&A answers
 # Single-model: set heavy = fast
 
+# ── Local Ollama (default) ────────────────────────────────────────────────────
 [ollama]
 url = "http://localhost:11434"   # supports LAN: http://192.168.1.x:11434
 timeout = 600
 fast_ctx = 16384                 # context window for fast model (tokens)
 heavy_ctx = 32768                # context window for heavy model (tokens)
+
+# ── Any other provider (replaces [ollama] when present) ──────────────────────
+# [provider]
+# name = "groq"                              # or lm_studio, vllm, together, azure, custom …
+# url  = "https://api.groq.com/openai/v1"
+# timeout = 120
+# fast_ctx = 8192
+# heavy_ctx = 32768
+# azure_api_version = "2024-02-15-preview"  # Azure only
 
 [pipeline]
 auto_approve = false             # true = skip draft review
@@ -280,6 +306,8 @@ max_concepts_per_source = 8      # limit concepts extracted per note
 watch_debounce = 3.0             # seconds after last file event before processing
 ingest_parallel = false          # true = parallel chunk analysis (needs OLLAMA_NUM_PARALLEL>=4)
 ```
+
+> **API keys** are never stored in `wiki.toml`. They are read at runtime from the provider-specific env var (e.g. `GROQ_API_KEY`), the generic `OLW_API_KEY` env var, or the `api_key` field in `~/.config/olw/config.toml` (written by `olw setup`).
 
 ### Tuning context windows
 
@@ -324,7 +352,7 @@ After editing `wiki.toml`, no reinstall is needed. Run `olw compile --force` to 
 
 | Command | Description |
 |---------|-------------|
-| `olw setup` | Interactive setup wizard (first run) |
+| `olw setup` | Interactive setup wizard: pick provider, models, vault |
 | `olw init PATH` | Create vault structure and git repo |
 | `olw init PATH --existing` | Adopt an existing Obsidian vault |
 | `olw doctor` | Check Ollama, models, vault structure |
@@ -359,15 +387,47 @@ All commands accept `--vault PATH` or the env var `OLW_VAULT`.
 
 ---
 
+## Providers
+
+Run `olw setup` to pick a provider interactively. All providers are also configurable directly in `wiki.toml`.
+
+| Provider | Type | Embeddings | Notes |
+|----------|------|-----------|-------|
+| **Ollama** | local | ✓ | default; full offline |
+| LM Studio | local | ✓ | |
+| vLLM | local | ✓ | |
+| llama.cpp | local | — | |
+| LocalAI | local | ✓ | |
+| TGI | local | — | |
+| SGLang | local | ✓ | |
+| Llamafile | local | — | |
+| Lemonade | local | — | |
+| **Groq** | cloud | — | fast inference, free tier |
+| Together AI | cloud | ✓ | |
+| Fireworks AI | cloud | ✓ | |
+| DeepInfra | cloud | ✓ | |
+| OpenRouter | cloud | — | routes to many models |
+| Mistral AI | cloud | ✓ | |
+| DeepSeek | cloud | — | |
+| SiliconFlow | cloud | ✓ | |
+| Perplexity | cloud | — | |
+| xAI (Grok) | cloud | — | |
+| Azure OpenAI | cloud | ✓ | see `azure_api_version` |
+| Custom | any | — | enter URL manually |
+
+RAG (embeddings) requires a provider that supports `/v1/embeddings`. The default index-based query works with all providers.
+
+---
+
 ## Model recommendations
 
-| Role | Recommended | Minimum |
-|------|-------------|---------|
-| Fast (analysis + routing) | `gemma4:e4b`, `llama3.2:3b` | any 3B with JSON format |
-| Heavy (article writing) | `qwen2.5:14b`, `llama3.1:8b` | any 7B |
-| Single model (everything) | `llama3.1:8b`, `mistral:7b` | any 7B |
+| Role | Ollama | Cloud |
+|------|--------|-------|
+| Fast (analysis + routing) | `gemma4:e4b`, `llama3.2:3b` | `llama-3.1-8b-instant` (Groq), `mistral-7b` |
+| Heavy (article writing) | `qwen2.5:14b`, `llama3.1:8b` | `llama-3.3-70b` (Groq), `mistral-large` |
+| Single model (everything) | `llama3.1:8b`, `mistral:7b` | any 7B+ |
 
-Any [Ollama model](https://ollama.com/library) with JSON format support works. The tool degrades gracefully with smaller models — they produce shorter, simpler articles but the pipeline still functions.
+Any model with JSON format / `response_format: json_object` support works. The tool degrades gracefully with smaller models.
 
 ---
 
@@ -468,6 +528,31 @@ Or manually block it:
 # Mark as blocked so compile skips it
 olw status   # shows blocked concepts
 ```
+
+---
+
+**Q: Can I use a cloud provider like Groq or Together AI instead of Ollama?**
+
+Yes. Run `olw setup` and select the provider from the numbered list. Enter your API key when prompted — it is stored only in `~/.config/olw/config.toml`. Alternatively set the provider-specific env var before each command:
+
+```bash
+export GROQ_API_KEY=gsk_...
+olw run
+```
+
+The pipeline, vault structure, and all `olw` commands work identically regardless of provider.
+
+---
+
+**Q: I changed providers in `olw setup` but `wiki.toml` still shows `[ollama]`.**
+
+Re-run `olw init` on your vault to sync the global config into `wiki.toml`:
+
+```bash
+olw init ~/my-wiki
+```
+
+For existing vaults with a `[ollama]` section you can also add a `[provider]` block manually — it takes precedence over `[ollama]` when present.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ After editing `wiki.toml`, no reinstall is needed. Run `olw compile --force` to 
 | `olw setup` | Interactive setup wizard: pick provider, models, vault |
 | `olw init PATH` | Create vault structure and git repo |
 | `olw init PATH --existing` | Adopt an existing Obsidian vault |
-| `olw doctor` | Check Ollama, models, vault structure |
+| `olw doctor` | Check provider connectivity, models, vault structure |
 | `olw run` | Full pipeline: ingest → compile → lint → [approve] |
 | `olw run --auto-approve` | Full pipeline, publish without review |
 | `olw run --dry-run` | Report what would happen, make no changes |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "obsidian-llm-wiki"
-version = "0.2.0"
-description = "Convert Obsidian notes into an AI-maintained wiki using local LLMs (100% local, Ollama)"
+version = "0.3.0"
+description = "Convert Obsidian notes into an AI-maintained wiki using local or cloud LLMs"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
@@ -57,6 +57,9 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/obsidian_llm_wiki/providers.py" = ["E501"]  # tabular registry data
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -118,9 +118,12 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     from .global_config import load_global_config
 
     gcfg = load_global_config()
-    fast = gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b"
-    heavy = gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b"
     provider_name = gcfg.provider_name if gcfg and gcfg.provider_name else "ollama"
+    # Only fall back to Ollama-specific model names when using Ollama; cloud providers
+    # must have been configured explicitly via `olw setup`.
+    _ollama = provider_name == "ollama"
+    fast = gcfg.fast_model if gcfg and gcfg.fast_model else ("gemma4:e4b" if _ollama else "")
+    heavy = gcfg.heavy_model if gcfg and gcfg.heavy_model else ("qwen2.5:14b" if _ollama else "")
     provider_url = gcfg.provider_url if gcfg and gcfg.provider_url else None
     ollama_url = gcfg.ollama_url if gcfg and gcfg.ollama_url else "http://localhost:11434"
     effective_url = provider_url or ollama_url
@@ -211,7 +214,14 @@ def _sync_wiki_toml_models(
     for section in ("ollama", "provider"):
         text = _replace_in_section(text, section, "url", ollama_url)
     if provider_name is not None:
-        text = _replace_in_section(text, "provider", "name", provider_name)
+        if "[provider]" not in text:
+            console.print(
+                f"  [yellow]Warning:[/yellow] wiki.toml has no [provider] section — "
+                f"provider '{provider_name}' not applied. "
+                f"Delete wiki.toml and re-run [bold]olw init[/bold] to regenerate it."
+            )
+        else:
+            text = _replace_in_section(text, "provider", "name", provider_name)
 
     if text != original:
         toml_path.write_text(text, encoding="utf-8")
@@ -499,8 +509,15 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             )
 
         # ── Default model names per provider ──────────────────────────────────
+        # For non-Ollama providers, leave defaults empty — model names are
+        # provider-specific and must be entered by the user.
         default_fast = "gemma4:e4b" if chosen_name == "ollama" else ""
         default_heavy = "qwen2.5:14b" if chosen_name == "ollama" else ""
+        if chosen_name != "ollama" and not connected:
+            console.print(
+                "    [dim]Tip: enter the model name exactly as the provider lists it "
+                "(e.g. llama-3.1-70b-versatile for Groq).[/dim]"
+            )
 
         step_offset = 1 if needs_key_prompt else 0
 
@@ -538,6 +555,17 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             vault_path = str(Path(vault_input).expanduser().resolve())
 
         # ── Save ──────────────────────────────────────────────────────────────
+        # Preserve existing azure_api_version so re-running setup doesn't reset it.
+        existing_cfg = load_global_config()
+        if chosen_name == "azure":
+            azure_api_ver = (
+                existing_cfg.azure_api_version
+                if existing_cfg and existing_cfg.azure_api_version
+                else "2024-02-15-preview"
+            )
+        else:
+            azure_api_ver = None
+
         # Keep ollama_url for backward compat when Ollama is selected
         cfg = GlobalConfig(
             vault=vault_path,
@@ -547,7 +575,7 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             provider_name=chosen_name,
             provider_url=provider_url,
             api_key=api_key,
-            azure_api_version="2024-02-15-preview" if chosen_name == "azure" else None,
+            azure_api_version=azure_api_ver,
         )
         save_global_config(cfg)
 

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -57,12 +57,12 @@ def _load_db(config):
 
 
 def _load_deps(config):
-    from .ollama_client import OllamaClient, OllamaError
+    from .client_factory import LLMError, build_client
 
-    client = OllamaClient(base_url=config.ollama.url, timeout=config.ollama.timeout)
+    client = build_client(config)
     try:
         client.require_healthy()
-    except OllamaError as e:
+    except LLMError as e:
         err_console.print(str(e))
         sys.exit(1)
     db = _load_db(config)
@@ -120,14 +120,38 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     gcfg = load_global_config()
     fast = gcfg.fast_model if gcfg and gcfg.fast_model else "gemma4:e4b"
     heavy = gcfg.heavy_model if gcfg and gcfg.heavy_model else "qwen2.5:14b"
+    provider_name = gcfg.provider_name if gcfg and gcfg.provider_name else "ollama"
+    provider_url = gcfg.provider_url if gcfg and gcfg.provider_url else None
     ollama_url = gcfg.ollama_url if gcfg and gcfg.ollama_url else "http://localhost:11434"
+    effective_url = provider_url or ollama_url
+    azure_api_version = gcfg.azure_api_version if gcfg and gcfg.azure_api_version else None
 
     if not toml_path.exists():
-        toml_path.write_text(default_wiki_toml(fast, heavy, ollama_url))
+        from .providers import get_provider
+
+        prov_info = get_provider(provider_name)
+        timeout = prov_info.default_timeout if prov_info else 600.0
+        toml_path.write_text(
+            default_wiki_toml(
+                fast,
+                heavy,
+                ollama_url=ollama_url,
+                provider_name=provider_name,
+                provider_url=effective_url if provider_name != "ollama" else None,
+                provider_timeout=timeout,
+                azure_api_version=azure_api_version,
+            )
+        )
     else:
         # Existing vault: patch model/URL fields from global config so that
         # olw setup changes are reflected without overwriting pipeline settings.
-        _sync_wiki_toml_models(toml_path, fast, heavy, ollama_url)
+        _sync_wiki_toml_models(
+            toml_path,
+            fast,
+            heavy,
+            effective_url,
+            provider_name=provider_name if provider_name != "ollama" else None,
+        )
 
     # Init git
     git_init(vault)
@@ -144,8 +168,14 @@ def init(vault_path: str, existing: bool, non_interactive: bool):
     console.print("  3. Review drafts: [bold]olw review[/bold]")
 
 
-def _sync_wiki_toml_models(toml_path: Path, fast: str, heavy: str, ollama_url: str) -> None:
-    """Patch fast/heavy model and Ollama URL in an existing wiki.toml in-place.
+def _sync_wiki_toml_models(
+    toml_path: Path,
+    fast: str,
+    heavy: str,
+    ollama_url: str,
+    provider_name: str | None = None,
+) -> None:
+    """Patch fast/heavy model, URL, and optionally provider name in an existing wiki.toml.
 
     Preserves all other settings (pipeline, rag, etc.) so user customisations
     are not lost. Only updates fields that come from global config.
@@ -167,6 +197,8 @@ def _sync_wiki_toml_models(toml_path: Path, fast: str, heavy: str, ollama_url: s
     text = _replace_value(text, "fast", fast)
     text = _replace_value(text, "heavy", heavy)
     text = _replace_value(text, "url", ollama_url)
+    if provider_name is not None:
+        text = _replace_value(text, "name", provider_name)
 
     if text != original:
         toml_path.write_text(text, encoding="utf-8")
@@ -276,10 +308,11 @@ def _pick_model(
 @cli.command()
 @click.option("--non-interactive", is_flag=True, help="Print current config and exit")
 @click.option("--reset", is_flag=True, help="Clear saved config and re-run wizard")
-def setup(non_interactive: bool, reset: bool):
-    """Interactive wizard: configure Ollama URL, models, and default vault."""
+@click.option("--provider", "provider_preset", default=None, help="Skip provider selection (e.g. groq, lm_studio)")
+def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
+    """Interactive wizard: configure provider, models, and default vault."""
     from .global_config import GlobalConfig, load_global_config, save_global_config
-    from .ollama_client import OllamaClient
+    from .providers import PROVIDER_REGISTRY, get_provider, list_all_providers
 
     # ── non-interactive: show current config ──────────────────────────────────
     if non_interactive:
@@ -292,9 +325,11 @@ def setup(non_interactive: bool, reset: bool):
         table = Table(title="Global config", show_header=False, box=None, padding=(0, 2))
         table.add_column("Key", style="bold")
         table.add_column("Value")
+        table.add_row("Provider", gcfg.provider_name or gcfg.ollama_url and "ollama" or "[dim]not set[/dim]")
+        table.add_row("URL", gcfg.provider_url or gcfg.ollama_url or "[dim]not set[/dim]")
+        table.add_row("API key", "***" if gcfg.api_key else "[dim]not set[/dim]")
         table.add_row("Fast model", gcfg.fast_model or "[dim]not set[/dim]")
         table.add_row("Heavy model", gcfg.heavy_model or "[dim]not set[/dim]")
-        table.add_row("Ollama URL", gcfg.ollama_url or "[dim]not set[/dim]")
         table.add_row("Default vault", gcfg.vault or "[dim]not set[/dim]")
         console.print(table)
         return
@@ -315,7 +350,7 @@ def setup(non_interactive: bool, reset: bool):
             _ver = "unknown"
         console.print(
             Panel(
-                f"[bold]obsidian-llm-wiki[/bold] v{_ver}  ·  first run setup",
+                f"[bold]obsidian-llm-wiki[/bold] v{_ver}  ·  setup",
                 expand=False,
                 border_style="blue",
                 padding=(0, 4),
@@ -323,55 +358,148 @@ def setup(non_interactive: bool, reset: bool):
         )
         console.print()
 
-        # ── Step 1/4 — Ollama connection ──────────────────────────────────────
-        DEFAULT_URL = "http://localhost:11434"
-        console.print("  [bold]Step 1/4[/bold]  Ollama connection")
+        all_providers = list_all_providers()
+        total_steps = 5  # provider, url, [api key], fast model, heavy model, vault
 
-        client = OllamaClient(base_url=DEFAULT_URL, timeout=5)
-        connected = client.healthcheck()
-
-        if connected:
-            console.print(f"    Trying {DEFAULT_URL} …  [green]✓ connected[/green]")
+        # ── Step 1 — Provider selection ───────────────────────────────────────
+        if provider_preset:
+            chosen_prov = get_provider(provider_preset)
+            if chosen_prov is None:
+                console.print(f"    [yellow]Unknown provider '{provider_preset}', using Ollama.[/yellow]")
+                chosen_prov = PROVIDER_REGISTRY["ollama"]
+            chosen_name = chosen_prov.name
         else:
-            console.print(f"    [yellow]Warning:[/yellow] Could not reach {DEFAULT_URL}")
+            console.print("  [bold]Step 1[/bold]  Provider\n")
+
+            # Build numbered list
+            local_provs = [p for p in all_providers if p.is_local]
+            cloud_provs = [p for p in all_providers if not p.is_local and p.name != "custom"]
+            custom_prov = PROVIDER_REGISTRY["custom"]
+
+            console.print("    [bold]Local[/bold] (no API key needed):")
+            idx_map: dict[int, str] = {}
+            counter = 1
+            for p in local_provs:
+                marker = "  [default]" if p.name == "ollama" else ""
+                console.print(f"      {counter:2}. {p.display_name:<14} {p.default_url}{marker}")
+                idx_map[counter] = p.name
+                counter += 1
+
+            console.print()
+            console.print("    [bold]Cloud[/bold] (API key required):")
+            for p in cloud_provs:
+                url_hint = p.default_url if p.default_url else "(enter URL manually)"
+                console.print(f"      {counter:2}. {p.display_name:<14} {url_hint}")
+                idx_map[counter] = p.name
+                counter += 1
+
+            console.print()
+            console.print(f"      {counter:2}. Custom         (enter URL manually)")
+            idx_map[counter] = "custom"
+
+            console.print()
+            raw = Prompt.ask("    Select provider (number or name)", default="1", console=console).strip()
+
+            if raw.isdigit():
+                num = int(raw)
+                chosen_name = idx_map.get(num, "ollama")
+            elif raw in PROVIDER_REGISTRY:
+                chosen_name = raw
+            else:
+                console.print(f"    [yellow]Unknown '{raw}', defaulting to Ollama.[/yellow]")
+                chosen_name = "ollama"
+
+            chosen_prov = PROVIDER_REGISTRY[chosen_name]
+
+        # ── Step 2 — URL ──────────────────────────────────────────────────────
+        console.print()
+        console.print("  [bold]Step 2[/bold]  URL")
+        default_url = chosen_prov.default_url or ""
+        if chosen_name == "azure":
             console.print(
-                "    You can still configure manually — run [bold]olw doctor[/bold] later."
+                "    Azure format: https://{resource}.openai.azure.com/openai/deployments/{model}"
+            )
+        provider_url = Prompt.ask("    Base URL", default=default_url, console=console).strip()
+        if not provider_url:
+            provider_url = default_url
+        if not provider_url and chosen_name in ("custom", "azure"):
+            console.print(
+                "    [red]URL is required for this provider. "
+                "Run [bold]olw setup[/bold] again and enter a valid URL.[/red]"
+            )
+            sys.exit(1)
+
+        # ── Step 3 — API key (cloud providers only) ───────────────────────────
+        api_key: str | None = None
+        if chosen_prov.requires_auth:
+            console.print()
+            console.print("  [bold]Step 3[/bold]  API key")
+            env_hint = f"  [dim](or set {chosen_prov.env_var} env var)[/dim]" if chosen_prov.env_var else ""
+            console.print(f"    API key{env_hint}")
+            raw_key = Prompt.ask("    Key", default="", password=True, console=console).strip()
+            api_key = raw_key if raw_key else None
+
+        # ── Build a temp client to probe for model list ───────────────────────
+        if chosen_name == "ollama":
+            from .ollama_client import OllamaClient
+
+            temp_client = OllamaClient(base_url=provider_url, timeout=5)
+        else:
+            from .openai_compat_client import OpenAICompatClient
+
+            import os
+            resolved_key = api_key
+            if not resolved_key and chosen_prov.env_var:
+                resolved_key = os.environ.get(chosen_prov.env_var)
+            if not resolved_key:
+                resolved_key = os.environ.get("OLW_API_KEY")
+            temp_client = OpenAICompatClient(
+                base_url=provider_url,
+                provider_name=chosen_name,
+                api_key=resolved_key,
+                timeout=5,
+                supports_json_mode=chosen_prov.supports_json_mode,
+                supports_embeddings=chosen_prov.supports_embeddings,
+                azure=chosen_prov.azure,
+            )
+        connected = temp_client.healthcheck()
+        if connected:
+            console.print(f"    [green]✓ connected[/green]")
+        else:
+            console.print(
+                f"    [yellow]Warning:[/yellow] Cannot reach {provider_url} — continuing anyway."
             )
 
-        ollama_url = Prompt.ask("    Ollama URL", default=DEFAULT_URL, console=console)
+        # ── Default model names per provider ──────────────────────────────────
+        default_fast = "gemma4:e4b" if chosen_name == "ollama" else ""
+        default_heavy = "qwen2.5:14b" if chosen_name == "ollama" else ""
 
-        if ollama_url != DEFAULT_URL:
-            client = OllamaClient(base_url=ollama_url, timeout=5)
-            connected = client.healthcheck()
-            if not connected:
-                console.print(
-                    f"    [yellow]Warning:[/yellow] Cannot reach {ollama_url} — continuing anyway."
-                )
+        step_offset = 1 if chosen_prov.requires_auth else 0
 
-        # ── Step 2/4 — Fast model ─────────────────────────────────────────────
+        # ── Step 4 — Fast model ───────────────────────────────────────────────
         fast_model = _pick_model(
             console=console,
-            client=client,
-            step_label="Step 2/4",
+            client=temp_client,
+            step_label=f"Step {3 + step_offset}",
             description="Fast model  [dim](analysis & routing · 3–8B recommended)[/dim]",
-            default_fallback="gemma4:e4b",
+            default_fallback=default_fast,
             connected=connected,
         )
 
-        # ── Step 3/4 — Heavy model ────────────────────────────────────────────
+        # ── Step 5 — Heavy model ──────────────────────────────────────────────
         heavy_model = _pick_model(
             console=console,
-            client=client,
-            step_label="Step 3/4",
+            client=temp_client,
+            step_label=f"Step {4 + step_offset}",
             description="Heavy model  [dim](article writing · 7–14B recommended)[/dim]",
-            default_fallback="qwen2.5:14b",
+            default_fallback=default_heavy,
             connected=connected,
         )
 
-        # ── Step 4/4 — Default vault ──────────────────────────────────────────
+        # ── Final step — Default vault ────────────────────────────────────────
         console.print()
         console.print(
-            "  [bold]Step 4/4[/bold]  Default vault path  [dim](press Enter to skip)[/dim]"
+            f"  [bold]Step {5 + step_offset}[/bold]  Default vault path  [dim](press Enter to skip)[/dim]"
         )
         vault_input = Prompt.ask("    Vault path", default="", console=console)
         vault_path: str | None = None
@@ -379,11 +507,16 @@ def setup(non_interactive: bool, reset: bool):
             vault_path = str(Path(vault_input).expanduser().resolve())
 
         # ── Save ──────────────────────────────────────────────────────────────
+        # Keep ollama_url for backward compat when Ollama is selected
         cfg = GlobalConfig(
             vault=vault_path,
-            ollama_url=ollama_url,
-            fast_model=fast_model,
-            heavy_model=heavy_model,
+            ollama_url=provider_url if chosen_name == "ollama" else None,
+            fast_model=fast_model if fast_model else None,
+            heavy_model=heavy_model if heavy_model else None,
+            provider_name=chosen_name,
+            provider_url=provider_url,
+            api_key=api_key,
+            azure_api_version="2024-02-15-preview" if chosen_name == "azure" else None,
         )
         save_global_config(cfg)
 
@@ -391,10 +524,15 @@ def setup(non_interactive: bool, reset: bool):
         init_target = vault_path or "~/my-wiki"
         summary_lines = [
             "[green]✓[/green]  Setup complete\n",
-            f"  Fast model:   [bold]{fast_model}[/bold]",
-            f"  Heavy model:  [bold]{heavy_model}[/bold]",
-            f"  Ollama:       {ollama_url}",
+            f"  Provider:     [bold]{chosen_prov.display_name}[/bold]",
+            f"  URL:          {provider_url}",
         ]
+        if api_key:
+            summary_lines.append("  API key:      ***")
+        if fast_model:
+            summary_lines.append(f"  Fast model:   [bold]{fast_model}[/bold]")
+        if heavy_model:
+            summary_lines.append(f"  Heavy model:  [bold]{heavy_model}[/bold]")
         if vault_path:
             summary_lines.append(f"  Vault:        {vault_path}")
         summary_lines += [
@@ -845,12 +983,13 @@ def clean(vault_str, yes):
 @cli.command()
 @click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
 def doctor(vault_str):
-    """Check Ollama connection, model availability, and vault health."""
-    from .ollama_client import OllamaClient, OllamaError
+    """Check LLM provider connection, model availability, and vault health."""
+    from .client_factory import LLMError, build_client
 
     config = _load_config(vault_str)
     db = _load_db(config)
     ok = True
+    prov = config.effective_provider
 
     console.print("[bold]olw doctor[/bold]\n")
 
@@ -879,13 +1018,13 @@ def doctor(vault_str):
         else:
             console.print(f"  [yellow]![/yellow] {name} missing (run [bold]olw init[/bold])")
 
-    # ── Ollama connection ────────────────────────────────────────────────────
-    console.print("\n[bold]Ollama[/bold]")
-    client = OllamaClient(base_url=config.ollama.url, timeout=10)
+    # ── Provider connection ───────────────────────────────────────────────────
+    console.print(f"\n[bold]{prov.name}[/bold]")
+    client = build_client(config)
     try:
         client.require_healthy()
-        console.print(f"  [green]✓[/green] Reachable at {config.ollama.url}")
-    except OllamaError as e:
+        console.print(f"  [green]✓[/green] Reachable at {prov.url}")
+    except LLMError as e:
         console.print(f"  [red]✗[/red] {e}")
         ok = False
 
@@ -900,9 +1039,13 @@ def doctor(vault_str):
         if any(model_name in a for a in available_models):
             console.print(f"  [green]✓[/green] {label}: {model_name}")
         else:
-            console.print(
-                f"  [yellow]![/yellow] {label}: {model_name} not found — "
+            pull_hint = (
                 f"run: [bold]ollama pull {model_name}[/bold]"
+                if prov.name == "ollama"
+                else "check provider model list"
+            )
+            console.print(
+                f"  [yellow]![/yellow] {label}: {model_name} not found — {pull_hint}"
             )
             ok = False
 

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -321,8 +321,12 @@ def _pick_model(
 @cli.command()
 @click.option("--non-interactive", is_flag=True, help="Print current config and exit")
 @click.option("--reset", is_flag=True, help="Clear saved config and re-run wizard")
-@click.option("--provider", "provider_preset", default=None,
-              help="Skip provider selection (e.g. groq, lm_studio)")
+@click.option(
+    "--provider",
+    "provider_preset",
+    default=None,
+    help="Skip provider selection (e.g. groq, lm_studio)",
+)
 def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
     """Interactive wizard: configure provider, models, and default vault."""
     from .global_config import GlobalConfig, load_global_config, save_global_config
@@ -1071,9 +1075,7 @@ def doctor(vault_str):
                 if prov.name == "ollama"
                 else "check provider model list"
             )
-            console.print(
-                f"  [yellow]![/yellow] {label}: {model_name} not found — {pull_hint}"
-            )
+            console.print(f"  [yellow]![/yellow] {label}: {model_name} not found — {pull_hint}")
             ok = False
 
     # ── Vault stats ───────────────────────────────────────────────────────────

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -179,6 +179,9 @@ def _sync_wiki_toml_models(
 
     Preserves all other settings (pipeline, rag, etc.) so user customisations
     are not lost. Only updates fields that come from global config.
+
+    URL is only updated within the [ollama] or [provider] section, never globally,
+    so switching providers cannot overwrite unrelated url= fields.
     """
     import re
 
@@ -194,11 +197,21 @@ def _sync_wiki_toml_models(
             flags=re.MULTILINE,
         )
 
+    def _replace_in_section(t: str, section: str, key: str, value: str) -> str:
+        """Replace key=value only within the named TOML section."""
+        escaped_val = value.replace("\\", "\\\\").replace('"', '\\"')
+        # Match the section header then capture everything until the next section or EOF
+        pattern = rf'(\[{re.escape(section)}\][^\[]*?)^({re.escape(key)}\s*=\s*)".+"'
+        replacement = rf'\1\2"{escaped_val}"'
+        return re.sub(pattern, replacement, t, flags=re.MULTILINE | re.DOTALL)
+
     text = _replace_value(text, "fast", fast)
     text = _replace_value(text, "heavy", heavy)
-    text = _replace_value(text, "url", ollama_url)
+    # Update URL only in [ollama] or [provider] sections to avoid clobbering other urls
+    for section in ("ollama", "provider"):
+        text = _replace_in_section(text, section, "url", ollama_url)
     if provider_name is not None:
-        text = _replace_value(text, "name", provider_name)
+        text = _replace_in_section(text, "provider", "name", provider_name)
 
     if text != original:
         toml_path.write_text(text, encoding="utf-8")
@@ -308,7 +321,8 @@ def _pick_model(
 @cli.command()
 @click.option("--non-interactive", is_flag=True, help="Print current config and exit")
 @click.option("--reset", is_flag=True, help="Clear saved config and re-run wizard")
-@click.option("--provider", "provider_preset", default=None, help="Skip provider selection (e.g. groq, lm_studio)")
+@click.option("--provider", "provider_preset", default=None,
+              help="Skip provider selection (e.g. groq, lm_studio)")
 def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
     """Interactive wizard: configure provider, models, and default vault."""
     from .global_config import GlobalConfig, load_global_config, save_global_config
@@ -325,7 +339,8 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
         table = Table(title="Global config", show_header=False, box=None, padding=(0, 2))
         table.add_column("Key", style="bold")
         table.add_column("Value")
-        table.add_row("Provider", gcfg.provider_name or gcfg.ollama_url and "ollama" or "[dim]not set[/dim]")
+        prov_display = gcfg.provider_name or (gcfg.ollama_url and "ollama") or "[dim]not set[/dim]"
+        table.add_row("Provider", prov_display)
         table.add_row("URL", gcfg.provider_url or gcfg.ollama_url or "[dim]not set[/dim]")
         table.add_row("API key", "***" if gcfg.api_key else "[dim]not set[/dim]")
         table.add_row("Fast model", gcfg.fast_model or "[dim]not set[/dim]")
@@ -359,13 +374,14 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
         console.print()
 
         all_providers = list_all_providers()
-        total_steps = 5  # provider, url, [api key], fast model, heavy model, vault
 
         # ── Step 1 — Provider selection ───────────────────────────────────────
         if provider_preset:
             chosen_prov = get_provider(provider_preset)
             if chosen_prov is None:
-                console.print(f"    [yellow]Unknown provider '{provider_preset}', using Ollama.[/yellow]")
+                console.print(
+                    f"    [yellow]Unknown provider '{provider_preset}', using Ollama.[/yellow]"
+                )
                 chosen_prov = PROVIDER_REGISTRY["ollama"]
             chosen_name = chosen_prov.name
         else:
@@ -374,7 +390,6 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             # Build numbered list
             local_provs = [p for p in all_providers if p.is_local]
             cloud_provs = [p for p in all_providers if not p.is_local and p.name != "custom"]
-            custom_prov = PROVIDER_REGISTRY["custom"]
 
             console.print("    [bold]Local[/bold] (no API key needed):")
             idx_map: dict[int, str] = {}
@@ -398,7 +413,9 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             idx_map[counter] = "custom"
 
             console.print()
-            raw = Prompt.ask("    Select provider (number or name)", default="1", console=console).strip()
+            raw = Prompt.ask(
+                "    Select provider (number or name)", default="1", console=console
+            ).strip()
 
             if raw.isdigit():
                 num = int(raw)
@@ -429,12 +446,20 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             )
             sys.exit(1)
 
-        # ── Step 3 — API key (cloud providers only) ───────────────────────────
+        # ── Step 3 — API key (cloud + custom providers) ───────────────────────
+        import os
+
+        needs_key_prompt = chosen_prov.requires_auth or chosen_name == "custom"
         api_key: str | None = None
-        if chosen_prov.requires_auth:
+        if needs_key_prompt:
             console.print()
             console.print("  [bold]Step 3[/bold]  API key")
-            env_hint = f"  [dim](or set {chosen_prov.env_var} env var)[/dim]" if chosen_prov.env_var else ""
+            if chosen_prov.env_var:
+                env_hint = f"  [dim](or set {chosen_prov.env_var} env var)[/dim]"
+            elif chosen_name == "custom":
+                env_hint = "  [dim](optional — press Enter to skip)[/dim]"
+            else:
+                env_hint = ""
             console.print(f"    API key{env_hint}")
             raw_key = Prompt.ask("    Key", default="", password=True, console=console).strip()
             api_key = raw_key if raw_key else None
@@ -447,7 +472,6 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
         else:
             from .openai_compat_client import OpenAICompatClient
 
-            import os
             resolved_key = api_key
             if not resolved_key and chosen_prov.env_var:
                 resolved_key = os.environ.get(chosen_prov.env_var)
@@ -464,7 +488,7 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             )
         connected = temp_client.healthcheck()
         if connected:
-            console.print(f"    [green]✓ connected[/green]")
+            console.print("    [green]✓ connected[/green]")
         else:
             console.print(
                 f"    [yellow]Warning:[/yellow] Cannot reach {provider_url} — continuing anyway."
@@ -474,7 +498,7 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
         default_fast = "gemma4:e4b" if chosen_name == "ollama" else ""
         default_heavy = "qwen2.5:14b" if chosen_name == "ollama" else ""
 
-        step_offset = 1 if chosen_prov.requires_auth else 0
+        step_offset = 1 if needs_key_prompt else 0
 
         # ── Step 4 — Fast model ───────────────────────────────────────────────
         fast_model = _pick_model(
@@ -496,10 +520,13 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             connected=connected,
         )
 
+        temp_client.close()
+
         # ── Final step — Default vault ────────────────────────────────────────
         console.print()
+        step_label = f"Step {5 + step_offset}"
         console.print(
-            f"  [bold]Step {5 + step_offset}[/bold]  Default vault path  [dim](press Enter to skip)[/dim]"
+            f"  [bold]{step_label}[/bold]  Default vault path  [dim](press Enter to skip)[/dim]"
         )
         vault_input = Prompt.ask("    Vault path", default="", console=console)
         vault_path: str | None = None

--- a/src/obsidian_llm_wiki/client_factory.py
+++ b/src/obsidian_llm_wiki/client_factory.py
@@ -1,0 +1,70 @@
+"""
+Factory for building the appropriate LLM client from config.
+
+Chooses between OllamaClient (native Ollama API) and OpenAICompatClient
+(all other providers) based on config.effective_provider.name.
+
+API key resolution order:
+  1. Provider-specific env var (e.g. GROQ_API_KEY)
+  2. Generic OLW_API_KEY env var
+  3. api_key field in global config (~/.config/olw/config.toml)
+  4. None — valid for local no-auth providers
+"""
+
+from __future__ import annotations
+
+import os
+
+from .config import Config
+from .openai_compat_client import LLMError, OpenAICompatClient
+from .protocols import LLMClientProtocol
+from .providers import ProviderInfo, get_provider
+
+
+def build_client(config: Config) -> LLMClientProtocol:
+    """Return the appropriate LLM client for the vault's provider config."""
+    prov = config.effective_provider
+
+    if prov.name == "ollama":
+        from .ollama_client import OllamaClient
+
+        return OllamaClient(base_url=prov.url, timeout=prov.timeout)
+
+    prov_info = get_provider(prov.name)
+    api_key = _resolve_api_key(prov.name, prov_info)
+
+    return OpenAICompatClient(
+        base_url=prov.url,
+        provider_name=prov.name,
+        api_key=api_key,
+        timeout=prov.timeout,
+        supports_json_mode=prov_info.supports_json_mode if prov_info else True,
+        supports_embeddings=prov_info.supports_embeddings if prov_info else False,
+        azure=prov_info.azure if prov_info else False,
+        azure_api_version=prov.azure_api_version,
+    )
+
+
+def _resolve_api_key(provider_name: str, prov_info: ProviderInfo | None) -> str | None:
+    # 1. Provider-specific env var (e.g. GROQ_API_KEY)
+    if prov_info and prov_info.env_var:
+        val = os.environ.get(prov_info.env_var)
+        if val:
+            return val
+
+    # 2. Generic env var
+    val = os.environ.get("OLW_API_KEY")
+    if val:
+        return val
+
+    # 3. Global config
+    from .global_config import load_global_config
+
+    gcfg = load_global_config()
+    if gcfg and gcfg.api_key:
+        return gcfg.api_key
+
+    return None
+
+
+__all__ = ["build_client", "LLMError"]

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -22,25 +22,52 @@ def default_wiki_toml(
     fast_model: str = "gemma4:e4b",
     heavy_model: str = "qwen2.5:14b",
     ollama_url: str = "http://localhost:11434",
+    provider_name: str = "ollama",
+    provider_url: str | None = None,
+    provider_timeout: float = 600.0,
+    azure_api_version: str | None = None,
 ) -> str:
-    """Generate wiki.toml content, optionally pre-filled from global config."""
+    """Generate wiki.toml content, optionally pre-filled from global config.
+
+    When provider_name is "ollama" (default), emits the legacy [ollama] section
+    so existing vaults keep working unchanged. Non-Ollama providers emit [provider].
+    """
+    if provider_name == "ollama":
+        url = provider_url or ollama_url
+        provider_section = (
+            f"[ollama]\n"
+            f"url = {_toml_quote(url)}\n"
+            f"timeout = 600\n"
+            f"fast_ctx = 16384                  # context window for fast model (tokens)\n"
+            f"heavy_ctx = 32768                 # context window for heavy model (tokens)\n"
+        )
+    else:
+        url = provider_url or ""
+        timeout_int = int(provider_timeout)
+        provider_section = (
+            f"[provider]\n"
+            f'name = "{provider_name}"\n'
+            f"url = {_toml_quote(url)}\n"
+            f"timeout = {timeout_int}\n"
+            f"fast_ctx = 8192                   # context window hint (tokens)\n"
+            f"heavy_ctx = 32768                 # context window hint (tokens)\n"
+        )
+        if provider_name == "azure":
+            api_ver = azure_api_version or "2024-02-15-preview"
+            provider_section += f'azure_api_version = "{api_ver}"\n'
     return (
         f"[models]\n"
         f"fast = {_toml_quote(fast_model)}\n"
         f"heavy = {_toml_quote(heavy_model)}\n"
         f"# Optional: set heavy = fast to use a single model for everything\n\n"
-        f"[ollama]\n"
-        f"url = {_toml_quote(ollama_url)}\n"
-        f"timeout = 600\n"
-        f"fast_ctx = 16384                  # context window for fast model (tokens)\n"
-        f"heavy_ctx = 32768                 # context window for heavy model (tokens)\n\n"
+        f"{provider_section}\n"
         f"[pipeline]\n"
         f"auto_approve = false\n"
         f"auto_commit = true\n"
         f"auto_maintain = false\n"
         f"watch_debounce = 3.0\n"
         f"max_concepts_per_source = 8\n"
-        f"ingest_parallel = false   # true = parallel chunks (needs OLLAMA_NUM_PARALLEL>=4)\n"
+        f"ingest_parallel = false   # true = parallel chunks\n"
     )
 
 
@@ -55,6 +82,17 @@ class OllamaConfig(BaseModel):
     timeout: float = 600.0  # seconds; 14B models over network need >5min
     fast_ctx: int = 16384
     heavy_ctx: int = 32768
+
+
+class ProviderConfig(BaseModel):
+    """New per-vault provider config. Supersedes [ollama] when present."""
+
+    name: str = "ollama"
+    url: str = "http://localhost:11434"
+    timeout: float = 600.0
+    fast_ctx: int = 16384
+    heavy_ctx: int = 32768
+    azure_api_version: str = "2024-02-15-preview"
 
 
 class PipelineConfig(BaseModel):
@@ -76,6 +114,7 @@ class Config(BaseModel):
     vault: Path
     models: ModelsConfig = ModelsConfig()
     ollama: OllamaConfig = OllamaConfig()
+    provider: ProviderConfig | None = None  # supersedes [ollama] when present
     pipeline: PipelineConfig = PipelineConfig()
     rag: RagConfig = RagConfig()
 
@@ -83,6 +122,19 @@ class Config(BaseModel):
     @classmethod
     def resolve_vault(cls, v: str | Path) -> Path:
         return Path(v).expanduser().resolve()
+
+    @property
+    def effective_provider(self) -> ProviderConfig:
+        """Return provider config, silently migrating [ollama] section if needed."""
+        if self.provider is not None:
+            return self.provider
+        return ProviderConfig(
+            name="ollama",
+            url=self.ollama.url,
+            timeout=self.ollama.timeout,
+            fast_ctx=self.ollama.fast_ctx,
+            heavy_ctx=self.ollama.heavy_ctx,
+        )
 
     @property
     def raw_dir(self) -> Path:

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -46,7 +46,7 @@ def default_wiki_toml(
         timeout_int = int(provider_timeout)
         provider_section = (
             f"[provider]\n"
-            f'name = "{provider_name}"\n'
+            f"name = {_toml_quote(provider_name)}\n"
             f"url = {_toml_quote(url)}\n"
             f"timeout = {timeout_int}\n"
             f"fast_ctx = 8192                   # context window hint (tokens)\n"
@@ -54,7 +54,7 @@ def default_wiki_toml(
         )
         if provider_name == "azure":
             api_ver = azure_api_version or "2024-02-15-preview"
-            provider_section += f'azure_api_version = "{api_ver}"\n'
+            provider_section += f"azure_api_version = {_toml_quote(api_ver)}\n"
     return (
         f"[models]\n"
         f"fast = {_toml_quote(fast_model)}\n"

--- a/src/obsidian_llm_wiki/global_config.py
+++ b/src/obsidian_llm_wiki/global_config.py
@@ -20,9 +20,14 @@ class GlobalConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     vault: str | None = None
-    ollama_url: str | None = None
+    ollama_url: str | None = None  # legacy — kept for backward compat
     fast_model: str | None = None
     heavy_model: str | None = None
+    # Provider fields (new in v0.3)
+    provider_name: str | None = None
+    provider_url: str | None = None
+    api_key: str | None = None  # never stored in wiki.toml; this file is user-private
+    azure_api_version: str | None = None  # Azure OpenAI API version (e.g. "2024-02-15-preview")
 
 
 def _global_config_path() -> Path:
@@ -59,6 +64,14 @@ def save_global_config(cfg: GlobalConfig) -> None:
         lines.append(f"fast_model = {_toml_str(cfg.fast_model)}")
     if cfg.heavy_model is not None:
         lines.append(f"heavy_model = {_toml_str(cfg.heavy_model)}")
+    if cfg.provider_name is not None:
+        lines.append(f"provider_name = {_toml_str(cfg.provider_name)}")
+    if cfg.provider_url is not None:
+        lines.append(f"provider_url = {_toml_str(cfg.provider_url)}")
+    if cfg.api_key is not None:
+        lines.append(f"api_key = {_toml_str(cfg.api_key)}")
+    if cfg.azure_api_version is not None:
+        lines.append(f"azure_api_version = {_toml_str(cfg.azure_api_version)}")
     path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
 
 

--- a/src/obsidian_llm_wiki/ollama_client.py
+++ b/src/obsidian_llm_wiki/ollama_client.py
@@ -9,6 +9,8 @@ import logging
 
 import httpx
 
+from .openai_compat_client import LLMError
+
 log = logging.getLogger(__name__)
 
 _STARTUP_HINT = (
@@ -21,7 +23,7 @@ _STARTUP_HINT = (
 )
 
 
-class OllamaError(Exception):
+class OllamaError(LLMError):
     pass
 
 

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -1,0 +1,250 @@
+"""
+OpenAI-compatible LLM client.
+
+Covers all providers that implement the /v1/chat/completions spec:
+  Local:  LM Studio, vLLM, llama.cpp, LocalAI, TGI, SGLang, Llamafile, Lemonade
+  Cloud:  Groq, Together AI, Fireworks, DeepInfra, OpenRouter, Mistral, DeepSeek,
+          SiliconFlow, Perplexity, xAI, Azure OpenAI
+
+URL construction: endpoints are appended directly to base_url, which must
+already include any path prefix (e.g. "https://api.groq.com/openai/v1").
+Azure base_url ends at the deployment level, so /chat/completions appends
+correctly without an extra /v1 segment.
+
+Auth:
+  - Standard providers: Authorization: Bearer {api_key}
+  - Azure:              api-key: {api_key}  +  ?api-version= query param
+  - Local no-auth:      no header
+
+JSON mode: if supports_json_mode=True, format="json" injects
+  response_format: {"type": "json_object"}.
+  If the provider returns HTTP 400, the request is retried once without it
+  (transparent auto-downgrade for models that reject the field).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+
+class LLMError(Exception):
+    """Base error for all LLM client failures (OllamaError inherits from this)."""
+
+
+class OpenAICompatClient:
+    def __init__(
+        self,
+        base_url: str,
+        provider_name: str = "custom",
+        api_key: str | None = None,
+        timeout: float = 300.0,
+        supports_json_mode: bool = True,
+        supports_embeddings: bool = False,
+        azure: bool = False,
+        azure_api_version: str = "2024-02-15-preview",
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.provider_name = provider_name
+        self._api_key = api_key
+        self._timeout = timeout
+        self.supports_json_mode = supports_json_mode
+        self.supports_embeddings = supports_embeddings
+        self._azure = azure
+        self._azure_api_version = azure_api_version
+        self._client = httpx.Client(
+            headers=self._build_headers(),
+            timeout=timeout,
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _build_headers(self) -> dict[str, str]:
+        if not self._api_key:
+            return {}
+        if self._azure:
+            return {"api-key": self._api_key}
+        return {"Authorization": f"Bearer {self._api_key}"}
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def _chat_url(self) -> str:
+        url = self._url("chat/completions")
+        if self._azure:
+            url = f"{url}?api-version={self._azure_api_version}"
+        return url
+
+    def _wrap_error(self, exc: Exception, context: str = "") -> LLMError:
+        prefix = f"{self.provider_name}: " if self.provider_name else ""
+        if isinstance(exc, httpx.ConnectError):
+            if self._is_local():
+                return LLMError(
+                    f"{prefix}Cannot connect to {self.base_url}. "
+                    f"Make sure the service is running."
+                )
+            return LLMError(
+                f"{prefix}Cannot reach {self.base_url}. "
+                f"Check your network connection."
+            )
+        if isinstance(exc, httpx.TimeoutException):
+            return LLMError(f"{prefix}Request timed out ({self._timeout}s). {context}")
+        if isinstance(exc, httpx.HTTPStatusError):
+            code = exc.response.status_code
+            if code == 401:
+                return LLMError(
+                    f"{prefix}HTTP 401 Unauthorized. Check your API key."
+                )
+            if code == 429:
+                return LLMError(
+                    f"{prefix}HTTP 429 Rate limit exceeded. Wait and retry."
+                )
+            return LLMError(
+                f"{prefix}HTTP {code}: {exc.response.text[:200]}"
+            )
+        return LLMError(f"{prefix}{exc}")
+
+    def _is_local(self) -> bool:
+        return self.base_url.startswith("http://localhost") or self.base_url.startswith(
+            "http://127.0.0.1"
+        )
+
+    # ── Health ────────────────────────────────────────────────────────────────
+
+    def healthcheck(self) -> bool:
+        try:
+            resp = self._client.get(self._url("models"), timeout=5)
+            # 200 = healthy + auth ok; 401 = service running but wrong key
+            return resp.status_code in (200, 401)
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return False
+        except Exception:
+            return False
+
+    def require_healthy(self) -> None:
+        if not self.healthcheck():
+            if self._is_local():
+                raise LLMError(
+                    f"Cannot reach {self.provider_name} at {self.base_url}. "
+                    f"Make sure the service is running."
+                )
+            raise LLMError(
+                f"Cannot reach {self.provider_name} at {self.base_url}. "
+                f"Check your network and API key."
+            )
+
+    def list_models(self) -> list[str]:
+        try:
+            resp = self._client.get(self._url("models"))
+            resp.raise_for_status()
+            return [m["id"] for m in resp.json().get("data", [])]
+        except (httpx.HTTPError, KeyError, ValueError):
+            return []
+
+    def list_models_detailed(self) -> list[dict]:
+        """Return list of {'name': str, 'size_gb': str} — matches OllamaClient shape."""
+        models = self.list_models()
+        return [{"name": m, "size_gb": "(cloud)"} for m in models]
+
+    # ── Generation ────────────────────────────────────────────────────────────
+
+    def generate(
+        self,
+        prompt: str,
+        model: str,
+        system: str = "",
+        format: str | None = None,
+        num_ctx: int = 8192,
+        num_predict: int = -1,
+    ) -> str:
+        """
+        Call /v1/chat/completions. Signature is identical to OllamaClient.generate().
+
+        num_ctx is silently ignored (server-managed for cloud providers).
+        num_predict > 0 maps to max_tokens; -1 omits the field (provider default).
+        format="json" injects response_format when supports_json_mode=True.
+        """
+        messages: list[dict] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        payload: dict = {"model": model, "messages": messages, "stream": False}
+
+        use_json_mode = format == "json" and self.supports_json_mode
+        if use_json_mode:
+            payload["response_format"] = {"type": "json_object"}
+
+        if num_predict > 0:
+            payload["max_tokens"] = num_predict
+
+        try:
+            resp = self._client.post(self._chat_url(), json=payload)
+            # Auto-downgrade: if provider rejects response_format, retry without it
+            if resp.status_code == 400 and use_json_mode:
+                log.debug(
+                    "%s: HTTP 400 with response_format, retrying without json mode",
+                    self.provider_name,
+                )
+                payload_no_json = {k: v for k, v in payload.items() if k != "response_format"}
+                resp = self._client.post(self._chat_url(), json=payload_no_json)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise self._wrap_error(e) from e
+        except httpx.ConnectError as e:
+            raise self._wrap_error(e) from e
+        except httpx.TimeoutException as e:
+            raise self._wrap_error(e) from e
+
+        try:
+            return resp.json()["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, ValueError) as e:
+            raise LLMError(
+                f"{self.provider_name}: unexpected response format: {resp.text[:200]}"
+            ) from e
+
+    # ── Embeddings ────────────────────────────────────────────────────────────
+
+    def embed_batch(self, texts: list[str], model: str = "nomic-embed-text") -> list[list[float]]:
+        if not texts:
+            return []
+        if not self.supports_embeddings:
+            raise LLMError(
+                f"{self.provider_name} does not support embeddings. "
+                f"Disable RAG or use a provider that supports it "
+                f"(Ollama, Together AI, Mistral AI, Fireworks AI, SiliconFlow)."
+            )
+        try:
+            resp = self._client.post(
+                self._url("embeddings"),
+                json={"model": model, "input": texts},
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise self._wrap_error(e) from e
+        except httpx.ConnectError as e:
+            raise self._wrap_error(e) from e
+        except httpx.TimeoutException as e:
+            raise self._wrap_error(e) from e
+
+        # OpenAI API may return embeddings out of order — sort by index
+        data = resp.json().get("data", [])
+        data.sort(key=lambda x: x.get("index", 0))
+        return [item["embedding"] for item in data]
+
+    def embed(self, text: str, model: str = "nomic-embed-text") -> list[float]:
+        return self.embed_batch([text], model=model)[0]
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> OpenAICompatClient:
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -72,11 +72,15 @@ class OpenAICompatClient:
     def _url(self, path: str) -> str:
         return f"{self.base_url}/{path.lstrip('/')}"
 
-    def _chat_url(self) -> str:
-        url = self._url("chat/completions")
+    def _api_url(self, path: str) -> str:
+        """Like _url() but appends ?api-version= for Azure endpoints."""
+        url = self._url(path)
         if self._azure:
             url = f"{url}?api-version={self._azure_api_version}"
         return url
+
+    def _chat_url(self) -> str:
+        return self._api_url("chat/completions")
 
     def _wrap_error(self, exc: Exception, context: str = "") -> LLMError:
         prefix = f"{self.provider_name}: " if self.provider_name else ""
@@ -116,7 +120,7 @@ class OpenAICompatClient:
 
     def healthcheck(self) -> bool:
         try:
-            resp = self._client.get(self._url("models"), timeout=5)
+            resp = self._client.get(self._api_url("models"), timeout=5)
             # 200 = healthy + auth ok; 401 = service running but wrong key
             return resp.status_code in (200, 401)
         except (httpx.ConnectError, httpx.TimeoutException):
@@ -138,7 +142,7 @@ class OpenAICompatClient:
 
     def list_models(self) -> list[str]:
         try:
-            resp = self._client.get(self._url("models"))
+            resp = self._client.get(self._api_url("models"))
             resp.raise_for_status()
             return [m["id"] for m in resp.json().get("data", [])]
         except (httpx.HTTPError, KeyError, ValueError):
@@ -219,7 +223,7 @@ class OpenAICompatClient:
             )
         try:
             resp = self._client.post(
-                self._url("embeddings"),
+                self._api_url("embeddings"),
                 json={"model": model, "input": texts},
             )
             resp.raise_for_status()
@@ -231,9 +235,14 @@ class OpenAICompatClient:
             raise self._wrap_error(e) from e
 
         # OpenAI API may return embeddings out of order — sort by index
-        data = resp.json().get("data", [])
-        data.sort(key=lambda x: x.get("index", 0))
-        return [item["embedding"] for item in data]
+        try:
+            data = resp.json().get("data", [])
+            data.sort(key=lambda x: x.get("index", 0))
+            return [item["embedding"] for item in data]
+        except (ValueError, KeyError) as e:
+            raise LLMError(
+                f"{self.provider_name}: unexpected embeddings response: {resp.text[:200]}"
+            ) from e
 
     def embed(self, text: str, model: str = "nomic-embed-text") -> list[float]:
         return self.embed_batch([text], model=model)[0]

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -82,6 +82,19 @@ class OpenAICompatClient:
     def _chat_url(self) -> str:
         return self._api_url("chat/completions")
 
+    def _models_url(self) -> str:
+        """Return the correct models/health endpoint URL.
+
+        Azure base_url ends at the deployment level, so /models appended there
+        gives an invalid path. Derive the resource-level URL by stripping
+        everything from /openai/ onwards, then append /openai/models.
+        """
+        if self._azure:
+            idx = self.base_url.find("/openai/")
+            resource = self.base_url[:idx] if idx >= 0 else self.base_url
+            return f"{resource}/openai/models?api-version={self._azure_api_version}"
+        return self._api_url("models")
+
     def _wrap_error(self, exc: Exception, context: str = "") -> LLMError:
         prefix = f"{self.provider_name}: " if self.provider_name else ""
         if isinstance(exc, httpx.ConnectError):
@@ -110,7 +123,7 @@ class OpenAICompatClient:
 
     def healthcheck(self) -> bool:
         try:
-            resp = self._client.get(self._api_url("models"), timeout=5)
+            resp = self._client.get(self._models_url(), timeout=5)
             # 200 = healthy + auth ok; 401 = service running but wrong key
             return resp.status_code in (200, 401)
         except (httpx.ConnectError, httpx.TimeoutException):
@@ -132,7 +145,7 @@ class OpenAICompatClient:
 
     def list_models(self) -> list[str]:
         try:
-            resp = self._client.get(self._api_url("models"))
+            resp = self._client.get(self._models_url())
             resp.raise_for_status()
             return [m["id"] for m in resp.json().get("data", [])]
         except (httpx.HTTPError, KeyError, ValueError):
@@ -188,9 +201,9 @@ class OpenAICompatClient:
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
             raise self._wrap_error(e) from e
-        except httpx.ConnectError as e:
-            raise self._wrap_error(e) from e
         except httpx.TimeoutException as e:
+            raise self._wrap_error(e) from e
+        except httpx.RequestError as e:
             raise self._wrap_error(e) from e
 
         try:
@@ -219,9 +232,9 @@ class OpenAICompatClient:
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
             raise self._wrap_error(e) from e
-        except httpx.ConnectError as e:
-            raise self._wrap_error(e) from e
         except httpx.TimeoutException as e:
+            raise self._wrap_error(e) from e
+        except httpx.RequestError as e:
             raise self._wrap_error(e) from e
 
         # OpenAI API may return embeddings out of order — sort by index

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -87,28 +87,18 @@ class OpenAICompatClient:
         if isinstance(exc, httpx.ConnectError):
             if self._is_local():
                 return LLMError(
-                    f"{prefix}Cannot connect to {self.base_url}. "
-                    f"Make sure the service is running."
+                    f"{prefix}Cannot connect to {self.base_url}. Make sure the service is running."
                 )
-            return LLMError(
-                f"{prefix}Cannot reach {self.base_url}. "
-                f"Check your network connection."
-            )
+            return LLMError(f"{prefix}Cannot reach {self.base_url}. Check your network connection.")
         if isinstance(exc, httpx.TimeoutException):
             return LLMError(f"{prefix}Request timed out ({self._timeout}s). {context}")
         if isinstance(exc, httpx.HTTPStatusError):
             code = exc.response.status_code
             if code == 401:
-                return LLMError(
-                    f"{prefix}HTTP 401 Unauthorized. Check your API key."
-                )
+                return LLMError(f"{prefix}HTTP 401 Unauthorized. Check your API key.")
             if code == 429:
-                return LLMError(
-                    f"{prefix}HTTP 429 Rate limit exceeded. Wait and retry."
-                )
-            return LLMError(
-                f"{prefix}HTTP {code}: {exc.response.text[:200]}"
-            )
+                return LLMError(f"{prefix}HTTP 429 Rate limit exceeded. Wait and retry.")
+            return LLMError(f"{prefix}HTTP {code}: {exc.response.text[:200]}")
         return LLMError(f"{prefix}{exc}")
 
     def _is_local(self) -> bool:

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -26,7 +26,7 @@ import frontmatter as fm_lib
 
 from ..config import Config
 from ..models import ArticlePlan, CompilePlan, SingleArticle, WikiArticleRecord
-from ..ollama_client import OllamaClient
+from ..protocols import LLMClientProtocol
 from ..sanitize import sanitize_tags
 from ..state import StateDB
 from ..structured_output import StructuredOutputError, request_structured
@@ -301,7 +301,7 @@ def _write_concept_prompt(
 
 def compile_concepts(
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     force: bool = False,
     dry_run: bool = False,
@@ -392,8 +392,8 @@ def compile_concepts(
                     model_class=SingleArticle,
                     model=config.models.fast,
                     system=_STUB_WRITE_SYSTEM,
-                    num_ctx=config.ollama.fast_ctx,
-                    num_predict=config.ollama.fast_ctx // 2,
+                    num_ctx=config.effective_provider.fast_ctx,
+                    num_predict=config.effective_provider.fast_ctx // 2,
                 )
             except StructuredOutputError as e:
                 log.error("Failed to write stub '%s': %s", name, e)
@@ -417,7 +417,7 @@ def compile_concepts(
 
         # Gather source material within context budget
         sources_text, resolved_paths = _gather_sources(
-            source_paths, config.vault, max_chars=config.ollama.heavy_ctx // 2
+            source_paths, config.vault, max_chars=config.effective_provider.heavy_ctx // 2
         )
         if not resolved_paths:
             log.warning("No readable sources for concept '%s', skipping", name)
@@ -452,8 +452,8 @@ def compile_concepts(
                 model_class=SingleArticle,
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
-                num_ctx=config.ollama.heavy_ctx,
-                num_predict=config.ollama.heavy_ctx // 2,
+                num_ctx=config.effective_provider.heavy_ctx,
+                num_predict=config.effective_provider.heavy_ctx // 2,
             )
         except StructuredOutputError as e:
             log.error("Failed to write '%s': %s", name, e)
@@ -514,7 +514,7 @@ def _write_prompt_legacy(article: ArticlePlan, sources: str, existing_titles: li
 
 def compile_notes(
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     rag=None,
     source_paths: list[str] | None = None,
@@ -559,7 +559,7 @@ def compile_notes(
             model_class=CompilePlan,
             model=config.models.fast,
             system=_PLAN_SYSTEM,
-            num_ctx=config.ollama.fast_ctx,
+            num_ctx=config.effective_provider.fast_ctx,
         )
     except StructuredOutputError as e:
         log.error("Planning failed: %s", e)
@@ -593,7 +593,7 @@ def compile_notes(
         sources_text, resolved_paths = _gather_sources(
             relevant,
             config.vault,
-            max_chars=config.ollama.heavy_ctx // 2,
+            max_chars=config.effective_provider.heavy_ctx // 2,
         )
 
         write_prompt = _write_prompt_legacy(article, sources_text, existing_titles)
@@ -605,8 +605,8 @@ def compile_notes(
                 model_class=SingleArticle,
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
-                num_ctx=config.ollama.heavy_ctx,
-                num_predict=config.ollama.heavy_ctx // 2,
+                num_ctx=config.effective_provider.heavy_ctx,
+                num_predict=config.effective_provider.heavy_ctx // 2,
             )
         except StructuredOutputError as e:
             log.error("Failed to write '%s': %s", article.title, e)

--- a/src/obsidian_llm_wiki/pipeline/ingest.py
+++ b/src/obsidian_llm_wiki/pipeline/ingest.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from ..config import Config
 from ..models import AnalysisResult, RawNoteRecord
-from ..ollama_client import OllamaClient
+from ..protocols import LLMClientProtocol
 from ..state import StateDB
 from ..structured_output import request_structured
 from ..vault import (
@@ -94,11 +94,11 @@ def _analyze_body(
     body: str,
     existing_concepts: list[str],
     path_name: str,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     config: Config,
 ) -> AnalysisResult:
     """Analyze note body, splitting into chunks if body exceeds fast_ctx // 2 chars."""
-    chunk_size = config.ollama.fast_ctx // 2
+    chunk_size = config.effective_provider.fast_ctx // 2
 
     if len(body) <= chunk_size:
         prompt = _build_analysis_prompt(body, existing_concepts, path_name)
@@ -108,7 +108,7 @@ def _analyze_body(
             model_class=AnalysisResult,
             model=config.models.fast,
             system=_SYSTEM,
-            num_ctx=config.ollama.fast_ctx,
+            num_ctx=config.effective_provider.fast_ctx,
         )
 
     # Split into chunks — no overlap needed for concept extraction
@@ -134,7 +134,7 @@ def _analyze_body(
             model_class=AnalysisResult,
             model=config.models.fast,
             system=_SYSTEM,
-            num_ctx=config.ollama.fast_ctx,
+            num_ctx=config.effective_provider.fast_ctx,
         )
         log.info("Analyzed %s %s (%.1fs)", path_name or "note", label, time.monotonic() - t0)
         return result
@@ -287,7 +287,7 @@ def _create_source_summary_page(
 def ingest_note(
     path: Path,
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     rag=None,  # Optional RAGStore, injected in Phase 2
     existing_topics: list[str] | None = None,  # existing concept names for prompt
@@ -392,7 +392,7 @@ def ingest_note(
 
 def ingest_all(
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     rag=None,
     force: bool = False,

--- a/src/obsidian_llm_wiki/pipeline/orchestrator.py
+++ b/src/obsidian_llm_wiki/pipeline/orchestrator.py
@@ -18,7 +18,7 @@ from enum import StrEnum
 from pathlib import Path
 
 from ..config import Config
-from ..ollama_client import OllamaClient
+from ..protocols import LLMClientProtocol
 from ..state import StateDB
 
 log = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class PipelineOrchestrator:
     pipeline lock before calling run() — this class does NOT lock internally.
     """
 
-    def __init__(self, config: Config, client: OllamaClient, db: StateDB) -> None:
+    def __init__(self, config: Config, client: LLMClientProtocol, db: StateDB) -> None:
         self.config = config
         self.client = client
         self.db = db
@@ -206,13 +206,13 @@ class PipelineOrchestrator:
 
 def _run_compile(
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     concepts: list[str] | None,
     dry_run: bool,
 ) -> tuple[list[Path], list[FailureRecord], dict[str, float]]:
     """Run compile_concepts and classify failures by reason."""
-    from ..ollama_client import OllamaError
+    from ..openai_compat_client import LLMError
     from ..pipeline.compile import compile_concepts
 
     try:
@@ -223,9 +223,9 @@ def _run_compile(
             dry_run=dry_run,
             concepts=concepts,
         )
-    except OllamaError as e:
+    except LLMError as e:
         # Connection-level failure — all concepts are transient
-        log.error("Ollama connection error during compile: %s", e)
+        log.error("LLM connection error during compile: %s", e)
         all_concepts = concepts or db.concepts_needing_compile()
         return (
             [],
@@ -239,7 +239,7 @@ def _run_compile(
     # Classify individual concept failures
     # compile_concepts returns bare names — we can't know the exact reason
     # per-concept without changing its return type. Use UNKNOWN for now;
-    # transient failures (timeouts) will bubble up as OllamaError above.
+    # transient failures (timeouts) will bubble up as LLMError above.
     failure_records = [
         FailureRecord(concept=name, reason=FailureReason.UNKNOWN) for name in failed_names
     ]

--- a/src/obsidian_llm_wiki/pipeline/query.py
+++ b/src/obsidian_llm_wiki/pipeline/query.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from ..config import Config
 from ..indexer import append_log, generate_index
 from ..models import PageSelection, QueryAnswer
-from ..ollama_client import OllamaClient
+from ..protocols import LLMClientProtocol
 from ..state import StateDB
 from ..structured_output import request_structured
 from ..vault import parse_note, sanitize_filename, write_note
@@ -80,7 +80,7 @@ def _load_pages(config: Config, page_titles: list[str]) -> str:
 
 def run_query(
     config: Config,
-    client: OllamaClient,
+    client: LLMClientProtocol,
     db: StateDB,
     question: str,
     save: bool = False,
@@ -109,7 +109,7 @@ def run_query(
         prompt=selection_prompt,
         model_class=PageSelection,
         model=config.models.fast,
-        num_ctx=config.ollama.fast_ctx,
+        num_ctx=config.effective_provider.fast_ctx,
         max_retries=2,
     )
 
@@ -131,7 +131,7 @@ def run_query(
         prompt=answer_prompt,
         model_class=QueryAnswer,
         model=config.models.heavy,
-        num_ctx=config.ollama.heavy_ctx,
+        num_ctx=config.effective_provider.heavy_ctx,
         max_retries=2,
     )
 

--- a/src/obsidian_llm_wiki/protocols.py
+++ b/src/obsidian_llm_wiki/protocols.py
@@ -1,0 +1,42 @@
+"""
+Shared protocol (structural interface) for LLM clients.
+
+Both OllamaClient and OpenAICompatClient implement this interface via
+duck typing. Using a Protocol keeps the code loosely coupled — no
+inheritance required, existing tests using MagicMock continue to work.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMClientProtocol(Protocol):
+    def generate(
+        self,
+        prompt: str,
+        model: str,
+        system: str = ...,
+        format: str | None = ...,
+        num_ctx: int = ...,
+        num_predict: int = ...,
+    ) -> str: ...
+
+    def embed_batch(self, texts: list[str], model: str = ...) -> list[list[float]]: ...
+
+    def embed(self, text: str, model: str = ...) -> list[float]: ...
+
+    def healthcheck(self) -> bool: ...
+
+    def require_healthy(self) -> None: ...
+
+    def list_models(self) -> list[str]: ...
+
+    def list_models_detailed(self) -> list[dict]: ...
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> LLMClientProtocol: ...
+
+    def __exit__(self, *args) -> None: ...

--- a/src/obsidian_llm_wiki/providers.py
+++ b/src/obsidian_llm_wiki/providers.py
@@ -1,0 +1,79 @@
+"""
+Provider registry for OpenAI-compatible LLM services.
+
+Each entry describes a known provider's default URL, auth requirements,
+and capability flags. The registry is used by the setup wizard and
+client factory — it is pure data with no runtime dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ProviderInfo:
+    name: str
+    display_name: str
+    default_url: str
+    requires_auth: bool
+    supports_json_mode: bool  # response_format: {type: json_object}
+    supports_embeddings: bool  # /v1/embeddings endpoint
+    is_local: bool
+    default_timeout: float  # seconds; local=600, cloud=120
+    env_var: str | None  # conventional env var for API key, e.g. "GROQ_API_KEY"
+    azure: bool = False  # uses api-key header + api-version query param
+
+
+# fmt: off
+PROVIDER_REGISTRY: dict[str, ProviderInfo] = {
+    # ── Local (no auth required, slow inference → long timeout) ──────────────
+    "ollama":     ProviderInfo("ollama",     "Ollama",     "http://localhost:11434",           False, True,  True,  True,  600.0, None),
+    "lm_studio":  ProviderInfo("lm_studio",  "LM Studio",  "http://localhost:1234/v1",         False, True,  True,  True,  600.0, None),
+    "vllm":       ProviderInfo("vllm",       "vLLM",       "http://localhost:8000/v1",         False, True,  True,  True,  600.0, None),
+    "llama_cpp":  ProviderInfo("llama_cpp",  "llama.cpp",  "http://localhost:8080/v1",         False, True,  False, True,  600.0, None),
+    "localai":    ProviderInfo("localai",    "LocalAI",    "http://localhost:8080/v1",         False, True,  True,  True,  600.0, None),
+    "tgi":        ProviderInfo("tgi",        "TGI",        "http://localhost:3000/v1",         False, True,  False, True,  600.0, None),
+    "sglang":     ProviderInfo("sglang",     "SGLang",     "http://localhost:30000/v1",        False, True,  True,  True,  600.0, None),
+    "llamafile":  ProviderInfo("llamafile",  "Llamafile",  "http://localhost:8080/v1",         False, True,  False, True,  600.0, None),
+    "lemonade":   ProviderInfo("lemonade",   "Lemonade",   "http://localhost:8000/v1",         False, True,  False, True,  600.0, None),
+    # ── Cloud (API key required, fast inference → short timeout) ─────────────
+    "groq":        ProviderInfo("groq",        "Groq",        "https://api.groq.com/openai/v1",          True, True,  False, False, 120.0, "GROQ_API_KEY"),
+    "together":    ProviderInfo("together",    "Together AI", "https://api.together.xyz/v1",             True, True,  True,  False, 120.0, "TOGETHER_API_KEY"),
+    "fireworks":   ProviderInfo("fireworks",   "Fireworks AI","https://api.fireworks.ai/inference/v1",   True, True,  True,  False, 120.0, "FIREWORKS_API_KEY"),
+    "deepinfra":   ProviderInfo("deepinfra",   "DeepInfra",   "https://api.deepinfra.com/v1/openai",     True, True,  True,  False, 120.0, "DEEPINFRA_API_KEY"),
+    "openrouter":  ProviderInfo("openrouter",  "OpenRouter",  "https://openrouter.ai/api/v1",            True, True,  False, False, 120.0, "OPENROUTER_API_KEY"),
+    "mistral":     ProviderInfo("mistral",     "Mistral AI",  "https://api.mistral.ai/v1",               True, True,  True,  False, 120.0, "MISTRAL_API_KEY"),
+    "deepseek":    ProviderInfo("deepseek",    "DeepSeek",    "https://api.deepseek.com/v1",             True, True,  False, False, 120.0, "DEEPSEEK_API_KEY"),
+    "siliconflow": ProviderInfo("siliconflow", "SiliconFlow", "https://api.siliconflow.cn/v1",           True, True,  True,  False, 120.0, "SILICONFLOW_API_KEY"),
+    "perplexity":  ProviderInfo("perplexity",  "Perplexity",  "https://api.perplexity.ai",               True, False, False, False, 120.0, "PERPLEXITY_API_KEY"),
+    "xai":         ProviderInfo("xai",         "xAI (Grok)",  "https://api.x.ai/v1",                    True, True,  False, False, 120.0, "XAI_API_KEY"),
+    "azure":       ProviderInfo("azure",       "Azure OpenAI","",                                        True, True,  True,  False, 120.0, "AZURE_OPENAI_API_KEY", azure=True),
+    # ── Custom / unknown provider ─────────────────────────────────────────────
+    "custom":      ProviderInfo("custom",      "Custom",      "",                                        False,True,  False, False, 300.0, None),
+}
+# fmt: on
+
+
+def get_provider(name: str) -> ProviderInfo | None:
+    """Return ProviderInfo for a known provider name, or None if unknown."""
+    return PROVIDER_REGISTRY.get(name)
+
+
+def list_local_providers() -> list[ProviderInfo]:
+    """Return all local (no-auth) providers, excluding 'ollama' (handled natively)."""
+    return [p for p in PROVIDER_REGISTRY.values() if p.is_local and p.name != "ollama"]
+
+
+def list_cloud_providers() -> list[ProviderInfo]:
+    """Return all cloud (auth-required) providers."""
+    return [p for p in PROVIDER_REGISTRY.values() if not p.is_local and p.name != "custom"]
+
+
+def list_all_providers() -> list[ProviderInfo]:
+    """Return all providers in display order: Ollama first, then local, then cloud, then custom."""
+    ollama = [PROVIDER_REGISTRY["ollama"]]
+    local = list_local_providers()
+    cloud = list_cloud_providers()
+    custom = [PROVIDER_REGISTRY["custom"]]
+    return ollama + local + cloud + custom

--- a/src/obsidian_llm_wiki/structured_output.py
+++ b/src/obsidian_llm_wiki/structured_output.py
@@ -169,7 +169,7 @@ def request_structured(
         client:      LLM client (OllamaClient or OpenAICompatClient)
         prompt:      User-facing prompt
         model_class: Pydantic model to parse response into
-        model:       Ollama model name
+        model:       Model name (passed to the LLM client)
         system:      Optional domain context (prepended before schema instruction)
         num_ctx:     Context window size
         max_retries: How many retry attempts after initial failure

--- a/src/obsidian_llm_wiki/structured_output.py
+++ b/src/obsidian_llm_wiki/structured_output.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, TypeVar
 from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
-    from .ollama_client import OllamaClient
+    from .protocols import LLMClientProtocol
 
 T = TypeVar("T", bound=BaseModel)
 log = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ def _try_parse(raw: str, model_class: type[T]) -> tuple[T | None, str]:
 
 
 def request_structured(
-    client: OllamaClient,
+    client: LLMClientProtocol,
     prompt: str,
     model_class: type[T],
     model: str,
@@ -163,10 +163,10 @@ def request_structured(
     max_retries: int = 2,
 ) -> T:
     """
-    Request structured output from Ollama, parse into Pydantic model.
+    Request structured output from an LLM client, parse into Pydantic model.
 
     Args:
-        client:      OllamaClient instance
+        client:      LLM client (OllamaClient or OpenAICompatClient)
         prompt:      User-facing prompt
         model_class: Pydantic model to parse response into
         model:       Ollama model name

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,511 @@
+"""
+Tests for providers registry, OpenAICompatClient, and client_factory.
+All tests are offline — no real provider required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from obsidian_llm_wiki.openai_compat_client import LLMError, OpenAICompatClient
+from obsidian_llm_wiki.providers import (
+    PROVIDER_REGISTRY,
+    get_provider,
+    list_all_providers,
+    list_cloud_providers,
+    list_local_providers,
+)
+
+
+@pytest.fixture
+def cfg_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect global config to a temp dir so tests don't touch ~/.config."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    return tmp_path
+
+
+# ── providers registry ────────────────────────────────────────────────────────
+
+
+def test_get_provider_known():
+    p = get_provider("groq")
+    assert p is not None
+    assert p.name == "groq"
+    assert p.requires_auth is True
+    assert p.default_url.startswith("https://")
+
+
+def test_get_provider_ollama():
+    p = get_provider("ollama")
+    assert p is not None
+    assert p.is_local is True
+    assert p.requires_auth is False
+
+
+def test_get_provider_unknown():
+    assert get_provider("nonexistent_provider_xyz") is None
+
+
+def test_list_local_excludes_ollama():
+    local = list_local_providers()
+    names = [p.name for p in local]
+    assert "ollama" not in names
+    assert all(p.is_local for p in local)
+    assert "lm_studio" in names
+
+
+def test_list_cloud_providers():
+    cloud = list_cloud_providers()
+    assert all(not p.is_local for p in cloud)
+    assert all(p.name != "custom" for p in cloud)
+    assert any(p.name == "groq" for p in cloud)
+
+
+def test_list_all_providers_order():
+    all_p = list_all_providers()
+    names = [p.name for p in all_p]
+    # Ollama first, custom last
+    assert names[0] == "ollama"
+    assert names[-1] == "custom"
+    # all providers present
+    assert "groq" in names
+    assert "lm_studio" in names
+
+
+# ── OpenAICompatClient ────────────────────────────────────────────────────────
+
+
+def _make_client(**kwargs) -> OpenAICompatClient:
+    defaults = dict(base_url="http://localhost:1234/v1", provider_name="test")
+    defaults.update(kwargs)
+    return OpenAICompatClient(**defaults)
+
+
+def test_generate_success():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "choices": [{"message": {"content": "hello world"}}]
+    }
+    with patch.object(client._client, "post", return_value=mock_resp):
+        result = client.generate("say hi", model="test-model")
+    assert result == "hello world"
+
+
+def test_generate_with_system():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+    captured = {}
+    def fake_post(url, json=None, **kw):
+        captured["payload"] = json
+        return mock_resp
+    with patch.object(client._client, "post", side_effect=fake_post):
+        client.generate("prompt", model="m", system="sys")
+    msgs = captured["payload"]["messages"]
+    assert msgs[0] == {"role": "system", "content": "sys"}
+    assert msgs[1] == {"role": "user", "content": "prompt"}
+
+
+def test_generate_json_mode_injected():
+    client = _make_client(supports_json_mode=True)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"choices": [{"message": {"content": "{}"}}]}
+    captured = {}
+    def fake_post(url, json=None, **kw):
+        captured["payload"] = json
+        return mock_resp
+    with patch.object(client._client, "post", side_effect=fake_post):
+        client.generate("p", model="m", format="json")
+    assert captured["payload"].get("response_format") == {"type": "json_object"}
+
+
+def test_generate_json_mode_400_retry():
+    """On 400 with json mode, client retries without response_format."""
+    client = _make_client(supports_json_mode=True)
+    bad_resp = MagicMock()
+    bad_resp.status_code = 400
+    bad_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=bad_resp
+    )
+    bad_resp.json.return_value = {}
+
+    good_resp = MagicMock()
+    good_resp.status_code = 200
+    good_resp.raise_for_status.return_value = None
+    good_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    call_count = {"n": 0}
+    def fake_post(url, json=None, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return bad_resp
+        return good_resp
+
+    with patch.object(client._client, "post", side_effect=fake_post):
+        result = client.generate("p", model="m", format="json")
+    assert result == "ok"
+    assert call_count["n"] == 2
+
+
+def test_generate_max_tokens_set_when_positive():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"choices": [{"message": {"content": "x"}}]}
+    captured = {}
+    def fake_post(url, json=None, **kw):
+        captured["payload"] = json
+        return mock_resp
+    with patch.object(client._client, "post", side_effect=fake_post):
+        client.generate("p", model="m", num_predict=512)
+    assert captured["payload"]["max_tokens"] == 512
+
+
+def test_generate_max_tokens_omitted_when_minus_one():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"choices": [{"message": {"content": "x"}}]}
+    captured = {}
+    def fake_post(url, json=None, **kw):
+        captured["payload"] = json
+        return mock_resp
+    with patch.object(client._client, "post", side_effect=fake_post):
+        client.generate("p", model="m", num_predict=-1)
+    assert "max_tokens" not in captured["payload"]
+
+
+def test_generate_connect_error_raises_llmerror():
+    client = _make_client()
+    with patch.object(client._client, "post", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(LLMError, match="Cannot connect"):
+            client.generate("p", model="m")
+
+
+def test_generate_timeout_raises_llmerror():
+    client = _make_client()
+    with patch.object(
+        client._client, "post", side_effect=httpx.ReadTimeout("timeout", request=MagicMock())
+    ):
+        with pytest.raises(LLMError, match="timed out"):
+            client.generate("p", model="m")
+
+
+def test_generate_401_raises_llmerror():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    err = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_resp)
+    with patch.object(client._client, "post", side_effect=err):
+        with pytest.raises(LLMError, match="401"):
+            client.generate("p", model="m")
+
+
+def test_healthcheck_true_on_200():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    with patch.object(client._client, "get", return_value=mock_resp):
+        assert client.healthcheck() is True
+
+
+def test_healthcheck_true_on_401():
+    """401 means server running but wrong key — still 'healthy' for connectivity."""
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 401
+    with patch.object(client._client, "get", return_value=mock_resp):
+        assert client.healthcheck() is True
+
+
+def test_healthcheck_false_on_connect_error():
+    client = _make_client()
+    with patch.object(client._client, "get", side_effect=httpx.ConnectError("refused")):
+        assert client.healthcheck() is False
+
+
+def test_list_models():
+    client = _make_client()
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = {"data": [{"id": "model-a"}, {"id": "model-b"}]}
+    with patch.object(client._client, "get", return_value=mock_resp):
+        models = client.list_models()
+    assert models == ["model-a", "model-b"]
+
+
+def test_list_models_detailed():
+    client = _make_client(provider_name="groq")
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = {"data": [{"id": "llama3"}]}
+    with patch.object(client._client, "get", return_value=mock_resp):
+        detailed = client.list_models_detailed()
+    assert detailed == [{"name": "llama3", "size_gb": "(cloud)"}]
+
+
+def test_embed_batch_no_embeddings_support():
+    client = _make_client(supports_embeddings=False)
+    with pytest.raises(LLMError, match="does not support embeddings"):
+        client.embed_batch(["text"], model="embed-model")
+
+
+def test_embed_batch_success():
+    client = _make_client(supports_embeddings=True)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.return_value = {
+        "data": [
+            {"index": 1, "embedding": [0.2, 0.3]},
+            {"index": 0, "embedding": [0.0, 0.1]},
+        ]
+    }
+    with patch.object(client._client, "post", return_value=mock_resp):
+        result = client.embed_batch(["a", "b"], model="embed")
+    # sorted by index
+    assert result == [[0.0, 0.1], [0.2, 0.3]]
+
+
+def test_azure_auth_header():
+    client = OpenAICompatClient(
+        base_url="https://my.openai.azure.com/openai/deployments/gpt4",
+        api_key="azure-key",
+        azure=True,
+    )
+    assert client._build_headers() == {"api-key": "azure-key"}
+
+
+def test_bearer_auth_header():
+    client = _make_client(api_key="sk-abc")
+    assert client._build_headers() == {"Authorization": "Bearer sk-abc"}
+
+
+def test_no_auth_header():
+    client = _make_client(api_key=None)
+    assert client._build_headers() == {}
+
+
+def test_azure_chat_url_includes_api_version():
+    client = OpenAICompatClient(
+        base_url="https://res.openai.azure.com/openai/deployments/gpt4",
+        azure=True,
+        azure_api_version="2024-02-15-preview",
+    )
+    url = client._chat_url()
+    assert "api-version=2024-02-15-preview" in url
+
+
+# ── client_factory ────────────────────────────────────────────────────────────
+
+
+def test_build_client_ollama(tmp_path):
+    from obsidian_llm_wiki.client_factory import build_client
+    from obsidian_llm_wiki.config import Config
+    from obsidian_llm_wiki.ollama_client import OllamaClient
+
+    config = Config(vault=tmp_path)
+    client = build_client(config)
+    assert isinstance(client, OllamaClient)
+
+
+def test_build_client_openai_compat(tmp_path):
+    from obsidian_llm_wiki.client_factory import build_client
+    from obsidian_llm_wiki.config import Config, ProviderConfig
+
+    config = Config(
+        vault=tmp_path,
+        provider=ProviderConfig(name="groq", url="https://api.groq.com/openai/v1"),
+    )
+    with patch.dict("os.environ", {"GROQ_API_KEY": "test-key"}):
+        client = build_client(config)
+    assert isinstance(client, OpenAICompatClient)
+    assert client.provider_name == "groq"
+
+
+def test_build_client_resolves_env_api_key(tmp_path):
+    from obsidian_llm_wiki.client_factory import build_client
+    from obsidian_llm_wiki.config import Config, ProviderConfig
+
+    config = Config(
+        vault=tmp_path,
+        provider=ProviderConfig(name="groq", url="https://api.groq.com/openai/v1"),
+    )
+    with patch.dict("os.environ", {"GROQ_API_KEY": "from-env"}):
+        client = build_client(config)
+    assert client._api_key == "from-env"
+
+
+def test_build_client_resolves_generic_olw_api_key(tmp_path):
+    from obsidian_llm_wiki.client_factory import build_client
+    from obsidian_llm_wiki.config import Config, ProviderConfig
+
+    config = Config(
+        vault=tmp_path,
+        provider=ProviderConfig(name="custom", url="http://localhost:9999/v1"),
+    )
+    with patch.dict("os.environ", {"OLW_API_KEY": "generic-key"}, clear=False):
+        client = build_client(config)
+    assert client._api_key == "generic-key"
+
+
+# ── embed_batch timeout ────────────────────────────────────────────────────────
+
+
+def test_embed_batch_timeout_raises_llmerror():
+    """Timeout during embeddings must raise LLMError, not propagate raw TimeoutException."""
+    client = _make_client(supports_embeddings=True)
+    with patch.object(
+        client._client,
+        "post",
+        side_effect=httpx.ReadTimeout("timeout", request=MagicMock()),
+    ):
+        with pytest.raises(LLMError, match="timed out"):
+            client.embed_batch(["text"], model="embed")
+
+
+# ── effective_provider backward compat ────────────────────────────────────────
+
+
+def test_effective_provider_legacy_ollama_section(tmp_path):
+    """Config with only [ollama] section (no [provider]) should migrate transparently."""
+    from obsidian_llm_wiki.config import Config, OllamaConfig
+
+    config = Config(vault=tmp_path, ollama=OllamaConfig(url="http://myhost:11434", timeout=300.0))
+    prov = config.effective_provider
+    assert prov.name == "ollama"
+    assert prov.url == "http://myhost:11434"
+    assert prov.timeout == 300.0
+
+
+def test_effective_provider_new_section_takes_priority(tmp_path):
+    """[provider] section overrides [ollama] when both present."""
+    from obsidian_llm_wiki.config import Config, OllamaConfig, ProviderConfig
+
+    config = Config(
+        vault=tmp_path,
+        ollama=OllamaConfig(url="http://old:11434"),
+        provider=ProviderConfig(name="groq", url="https://api.groq.com/openai/v1"),
+    )
+    prov = config.effective_provider
+    assert prov.name == "groq"
+    assert "groq" in prov.url
+
+
+def test_build_client_legacy_ollama_config(tmp_path):
+    """build_client() with default (legacy) Config must return OllamaClient."""
+    from obsidian_llm_wiki.client_factory import build_client
+    from obsidian_llm_wiki.config import Config
+    from obsidian_llm_wiki.ollama_client import OllamaClient
+
+    config = Config(vault=tmp_path)  # no [provider] — uses [ollama] defaults
+    client = build_client(config)
+    assert isinstance(client, OllamaClient)
+
+
+# ── azure_api_version in wiki.toml ────────────────────────────────────────────
+
+
+def test_default_wiki_toml_azure_includes_api_version():
+    from obsidian_llm_wiki.config import default_wiki_toml
+
+    toml = default_wiki_toml(
+        provider_name="azure",
+        provider_url="https://myres.openai.azure.com/openai/deployments/gpt4",
+        azure_api_version="2024-05-01-preview",
+    )
+    assert "azure_api_version" in toml
+    assert "2024-05-01-preview" in toml
+
+
+def test_default_wiki_toml_non_azure_no_api_version():
+    from obsidian_llm_wiki.config import default_wiki_toml
+
+    toml = default_wiki_toml(provider_name="groq", provider_url="https://api.groq.com/openai/v1")
+    assert "azure_api_version" not in toml
+
+
+# ── setup wizard edge cases ────────────────────────────────────────────────────
+
+
+def test_setup_wizard_cloud_provider_empty_api_key(tmp_path, cfg_dir):
+    """Cloud provider with empty API key: config saved with api_key=None."""
+    from click.testing import CliRunner
+
+    from obsidian_llm_wiki.cli import cli
+    from obsidian_llm_wiki.global_config import load_global_config
+    from obsidian_llm_wiki.providers import list_all_providers
+
+    runner = CliRunner()
+    groq_number = next(
+        str(i) for i, p in enumerate(list_all_providers(), 1) if p.name == "groq"
+    )
+
+    with patch("obsidian_llm_wiki.openai_compat_client.OpenAICompatClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        # provider=groq, URL=default, api_key=empty(Enter), fast, heavy, no vault
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            input=f"{groq_number}\n\n\nllama3\nllama3\n\n",
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.provider_name == "groq"
+    assert cfg.api_key is None
+
+
+def test_setup_wizard_azure_saves_provider_name(tmp_path, cfg_dir):
+    """Azure setup wizard should save provider_name='azure' and azure_api_version."""
+    from click.testing import CliRunner
+
+    from obsidian_llm_wiki.cli import cli
+    from obsidian_llm_wiki.global_config import load_global_config
+    from obsidian_llm_wiki.providers import list_all_providers
+
+    runner = CliRunner()
+    # Find Azure's menu number
+    azure_number = next(
+        str(i)
+        for i, p in enumerate(list_all_providers(), 1)
+        if p.name == "azure"
+    )
+
+    with patch("obsidian_llm_wiki.openai_compat_client.OpenAICompatClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            # provider=azure, URL, api key, fast model, heavy model, no vault
+            input=f"{azure_number}\nhttps://myres.openai.azure.com/openai/deployments/gpt4\nmy-key\nmodel-a\nmodel-b\n\n",
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.provider_name == "azure"
+    assert cfg.azure_api_version == "2024-02-15-preview"
+    assert cfg.api_key == "my-key"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,7 +13,6 @@ import pytest
 
 from obsidian_llm_wiki.openai_compat_client import LLMError, OpenAICompatClient
 from obsidian_llm_wiki.providers import (
-    PROVIDER_REGISTRY,
     get_provider,
     list_all_providers,
     list_cloud_providers,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -89,9 +89,7 @@ def test_generate_success():
     client = _make_client()
     mock_resp = MagicMock()
     mock_resp.status_code = 200
-    mock_resp.json.return_value = {
-        "choices": [{"message": {"content": "hello world"}}]
-    }
+    mock_resp.json.return_value = {"choices": [{"message": {"content": "hello world"}}]}
     with patch.object(client._client, "post", return_value=mock_resp):
         result = client.generate("say hi", model="test-model")
     assert result == "hello world"
@@ -103,9 +101,11 @@ def test_generate_with_system():
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
     captured = {}
+
     def fake_post(url, json=None, **kw):
         captured["payload"] = json
         return mock_resp
+
     with patch.object(client._client, "post", side_effect=fake_post):
         client.generate("prompt", model="m", system="sys")
     msgs = captured["payload"]["messages"]
@@ -119,9 +119,11 @@ def test_generate_json_mode_injected():
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"choices": [{"message": {"content": "{}"}}]}
     captured = {}
+
     def fake_post(url, json=None, **kw):
         captured["payload"] = json
         return mock_resp
+
     with patch.object(client._client, "post", side_effect=fake_post):
         client.generate("p", model="m", format="json")
     assert captured["payload"].get("response_format") == {"type": "json_object"}
@@ -143,6 +145,7 @@ def test_generate_json_mode_400_retry():
     good_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
 
     call_count = {"n": 0}
+
     def fake_post(url, json=None, **kw):
         call_count["n"] += 1
         if call_count["n"] == 1:
@@ -161,9 +164,11 @@ def test_generate_max_tokens_set_when_positive():
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"choices": [{"message": {"content": "x"}}]}
     captured = {}
+
     def fake_post(url, json=None, **kw):
         captured["payload"] = json
         return mock_resp
+
     with patch.object(client._client, "post", side_effect=fake_post):
         client.generate("p", model="m", num_predict=512)
     assert captured["payload"]["max_tokens"] == 512
@@ -175,9 +180,11 @@ def test_generate_max_tokens_omitted_when_minus_one():
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"choices": [{"message": {"content": "x"}}]}
     captured = {}
+
     def fake_post(url, json=None, **kw):
         captured["payload"] = json
         return mock_resp
+
     with patch.object(client._client, "post", side_effect=fake_post):
         client.generate("p", model="m", num_predict=-1)
     assert "max_tokens" not in captured["payload"]
@@ -447,9 +454,7 @@ def test_setup_wizard_cloud_provider_empty_api_key(tmp_path, cfg_dir):
     from obsidian_llm_wiki.providers import list_all_providers
 
     runner = CliRunner()
-    groq_number = next(
-        str(i) for i, p in enumerate(list_all_providers(), 1) if p.name == "groq"
-    )
+    groq_number = next(str(i) for i, p in enumerate(list_all_providers(), 1) if p.name == "groq")
 
     with patch("obsidian_llm_wiki.openai_compat_client.OpenAICompatClient") as MockClient:
         instance = MagicMock()
@@ -482,11 +487,7 @@ def test_setup_wizard_azure_saves_provider_name(tmp_path, cfg_dir):
 
     runner = CliRunner()
     # Find Azure's menu number
-    azure_number = next(
-        str(i)
-        for i, p in enumerate(list_all_providers(), 1)
-        if p.name == "azure"
-    )
+    azure_number = next(str(i) for i, p in enumerate(list_all_providers(), 1) if p.name == "azure")
 
     with patch("obsidian_llm_wiki.openai_compat_client.OpenAICompatClient") as MockClient:
         instance = MagicMock()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -245,7 +245,8 @@ def test_setup_wizard_saves_config(runner: CliRunner, cfg_dir: Path):
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\n\ngemma4:e4b\nqwen2.5:14b\n\n",  # provider default, URL default, fast, heavy, no vault
+            # provider default, URL default, fast, heavy, no vault
+            input="\n\ngemma4:e4b\nqwen2.5:14b\n\n",
             catch_exceptions=False,
         )
 
@@ -270,7 +271,8 @@ def test_setup_wizard_model_number_selection(runner: CliRunner, cfg_dir: Path):
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\n\n1\n2\n\n",  # provider default, URL default, pick #1 fast, pick #2 heavy, no vault
+            # provider default, URL default, pick #1 fast, pick #2 heavy, no vault
+            input="\n\n1\n2\n\n",
             catch_exceptions=False,
         )
 
@@ -293,7 +295,8 @@ def test_setup_wizard_whitespace_input_uses_default(runner: CliRunner, cfg_dir: 
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\n\n   \n   \n\n",  # provider default, URL default, spaces for fast, spaces for heavy, no vault
+            # provider default, URL default, spaces for fast, spaces for heavy, no vault
+            input="\n\n   \n   \n\n",
             catch_exceptions=False,
         )
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -221,7 +221,7 @@ def test_setup_reset_clears_config(runner: CliRunner, cfg_dir: Path):
     result = runner.invoke(
         cli,
         ["setup", "--reset"],
-        input="\n\n\n\n",
+        input="\n\n\n\n\n",
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -245,7 +245,7 @@ def test_setup_wizard_saves_config(runner: CliRunner, cfg_dir: Path):
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\ngemma4:e4b\nqwen2.5:14b\n\n",  # URL default, fast, heavy, no vault
+            input="\n\ngemma4:e4b\nqwen2.5:14b\n\n",  # provider default, URL default, fast, heavy, no vault
             catch_exceptions=False,
         )
 
@@ -270,7 +270,7 @@ def test_setup_wizard_model_number_selection(runner: CliRunner, cfg_dir: Path):
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\n1\n2\n\n",  # URL default, pick #1 fast, pick #2 heavy, no vault
+            input="\n\n1\n2\n\n",  # provider default, URL default, pick #1 fast, pick #2 heavy, no vault
             catch_exceptions=False,
         )
 
@@ -293,7 +293,7 @@ def test_setup_wizard_whitespace_input_uses_default(runner: CliRunner, cfg_dir: 
         result = runner.invoke(
             cli,
             ["setup"],
-            input="\n   \n   \n\n",  # URL default, spaces for fast, spaces for heavy, no vault
+            input="\n\n   \n   \n\n",  # provider default, URL default, spaces for fast, spaces for heavy, no vault
             catch_exceptions=False,
         )
 
@@ -318,7 +318,7 @@ def test_setup_wizard_with_vault(runner: CliRunner, cfg_dir: Path, tmp_path: Pat
         result = runner.invoke(
             cli,
             ["setup"],
-            input=f"\ngemma4:e4b\nqwen2.5:14b\n{vault}\n",
+            input=f"\n\ngemma4:e4b\nqwen2.5:14b\n{vault}\n",
             catch_exceptions=False,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Add support for any OpenAI-compatible LLM provider alongside Ollama.

New modules:
- protocols.py — LLMClientProtocol structural interface
- providers.py — registry of 20 local and cloud providers
- openai_compat_client.py — /v1/chat/completions client with Azure support
- client_factory.py — build_client() resolves the right client from config

Pipeline changes:
- All pipeline stages (ingest, compile, query, orchestrator, structured_output) now depend on LLMClientProtocol instead of OllamaClient directly
- config.effective_provider replaces config.ollama in context window lookups
- New [provider] section in wiki.toml; existing [ollama] sections migrate transparently via effective_provider

Setup wizard gains provider selection as Step 1 (numbered list of local and cloud providers). API keys stored only in ~/.config/olw/config.toml, never in wiki.toml. azure_api_version flows from global config into wiki.toml for Azure vaults.

Bug fixes:
- embed_batch now wraps TimeoutException as LLMError
- Setup wizard temp client passes azure=True and supports_embeddings flags
- Empty URL for custom/azure provider exits with clear error

Tests: 38 new tests covering OpenAICompatClient, providers registry, client_factory, effective_provider backward compat, and setup wizard flows. All 373 tests pass. Smoke test: 64/64 checks green.

Docs: README updated with provider table, setup wizard example, updated configuration section, cloud model recommendations. CHANGELOG entry for v0.3.