### PR TITLE
chore: release v0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-llm-wiki"
-version = "0.3.0"
+version = "0.3.1"
 description = "Convert Obsidian notes into an AI-maintained wiki using local or cloud LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -46,7 +46,8 @@ case "$PROVIDER" in
         HEAVY_MODEL="${HEAVY_MODEL:-}"
         FAST_CTX="${FAST_CTX:-8192}"
         HEAVY_CTX="${HEAVY_CTX:-16384}"
-        if [[ -z "$PROVIDER_URL" || -z "$FAST_MODEL" ]]; then
+        HEAVY_MODEL="${HEAVY_MODEL:-$FAST_MODEL}"
+        if [[ -z "$PROVIDER_URL" || -z "$FAST_MODEL" || -z "$HEAVY_MODEL" ]]; then
             echo "ERROR: PROVIDER=$PROVIDER requires PROVIDER_URL and FAST_MODEL to be set."
             exit 1
         fi
@@ -118,8 +119,8 @@ if [[ "$PROVIDER" == "ollama" ]]; then
         fi
     fi
 
-    check "Fast model present: $FAST_MODEL"  "curl -sf $PROVIDER_URL/api/tags | grep -q '$FAST_MODEL'"
-    check "Heavy model present: $HEAVY_MODEL" "curl -sf $PROVIDER_URL/api/tags | grep -q '$HEAVY_MODEL'"
+    check "Fast model present: $FAST_MODEL"  "curl -sf $PROVIDER_URL/api/tags | grep -F -q '$FAST_MODEL'"
+    check "Heavy model present: $HEAVY_MODEL" "curl -sf $PROVIDER_URL/api/tags | grep -F -q '$HEAVY_MODEL'"
 else
     # LM Studio and other OpenAI-compatible providers: just verify the endpoint is up.
     # Model presence can't be checked reliably via /v1/models on all backends.

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,22 +1,58 @@
 #!/usr/bin/env bash
-# smoke_test.sh — end-to-end test against a real Ollama instance
+# smoke_test.sh — end-to-end test against a real LLM backend
+#
+# Supports Ollama (default) and LM Studio (PROVIDER=lm_studio).
 #
 # Usage:
-#   ./scripts/smoke_test.sh                        # use default models
-#   FAST_MODEL=llama3.2:latest ./scripts/smoke_test.sh   # override models
+#   ./scripts/smoke_test.sh                              # Ollama, default models
+#   PROVIDER=lm_studio ./scripts/smoke_test.sh           # LM Studio
+#   PROVIDER=lm_studio FAST_MODEL=google/gemma-4-e4b ./scripts/smoke_test.sh
+#   FAST_MODEL=llama3.2:latest ./scripts/smoke_test.sh   # Ollama, custom model
 #   VAULT_DIR=/tmp/my-vault ./scripts/smoke_test.sh      # keep vault after run
-#   SKIP_PULL=1 ./scripts/smoke_test.sh            # skip ollama pull
+#   SKIP_PULL=1 ./scripts/smoke_test.sh                  # skip ollama pull
 #
 # Requirements:
 #   - uv (https://docs.astral.sh/uv/)
-#   - Ollama running (ollama serve)
+#   - Ollama running (ollama serve)  — OR —  LM Studio running with a model loaded
 
 set -euo pipefail
 
 # ── Config ────────────────────────────────────────────────────────────────────
-FAST_MODEL="${FAST_MODEL:-gemma4:e4b}"
-HEAVY_MODEL="${HEAVY_MODEL:-gemma4:e4b}"
-OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+PROVIDER="${PROVIDER:-ollama}"
+
+case "$PROVIDER" in
+    ollama)
+        # OLLAMA_URL kept for backward compatibility
+        PROVIDER_URL="${PROVIDER_URL:-${OLLAMA_URL:-http://localhost:11434}}"
+        FAST_MODEL="${FAST_MODEL:-gemma4:e4b}"
+        HEAVY_MODEL="${HEAVY_MODEL:-gemma4:e4b}"
+        FAST_CTX=8192
+        HEAVY_CTX=16384
+        ;;
+    lm_studio)
+        PROVIDER_URL="${PROVIDER_URL:-http://localhost:1234/v1}"
+        FAST_MODEL="${FAST_MODEL:-google/gemma-4-e4b}"
+        HEAVY_MODEL="${HEAVY_MODEL:-google/gemma-4-e4b}"
+        FAST_CTX=8192
+        # Keep output budget + input within 8192: source uses heavy_ctx//2 tokens,
+        # output uses _MAX_ARTICLE_PREDICT=4096. Total = 4096+4096+~800 overhead > 8192.
+        # Use 8192 so _gather_sources truncates aggressively enough for short test notes.
+        HEAVY_CTX=8192
+        ;;
+    *)
+        # Generic OpenAI-compatible provider — caller must set PROVIDER_URL and models
+        PROVIDER_URL="${PROVIDER_URL:-}"
+        FAST_MODEL="${FAST_MODEL:-}"
+        HEAVY_MODEL="${HEAVY_MODEL:-}"
+        FAST_CTX="${FAST_CTX:-8192}"
+        HEAVY_CTX="${HEAVY_CTX:-16384}"
+        if [[ -z "$PROVIDER_URL" || -z "$FAST_MODEL" ]]; then
+            echo "ERROR: PROVIDER=$PROVIDER requires PROVIDER_URL and FAST_MODEL to be set."
+            exit 1
+        fi
+        ;;
+esac
+
 SKIP_PULL="${SKIP_PULL:-0}"
 KEEP_VAULT="${KEEP_VAULT:-0}"
 
@@ -67,19 +103,29 @@ cleanup() {
 trap cleanup EXIT
 
 # ── Prerequisites ─────────────────────────────────────────────────────────────
-header "Prerequisites"
+header "Prerequisites (provider: $PROVIDER)"
 
 check "uv available" "command -v uv"
-check "Ollama reachable at $OLLAMA_URL" "curl -sf $OLLAMA_URL/api/tags"
 
-if [[ "$SKIP_PULL" == "0" ]]; then
-    info "Pulling models (skippable with SKIP_PULL=1)"
-    ollama pull "$FAST_MODEL"   || fail "Could not pull $FAST_MODEL"
-    ollama pull "$HEAVY_MODEL"  || fail "Could not pull $HEAVY_MODEL"
+if [[ "$PROVIDER" == "ollama" ]]; then
+    check "Ollama reachable at $PROVIDER_URL" "curl -sf $PROVIDER_URL/api/tags"
+
+    if [[ "$SKIP_PULL" == "0" ]]; then
+        info "Pulling models (skippable with SKIP_PULL=1)"
+        ollama pull "$FAST_MODEL"  || fail "Could not pull $FAST_MODEL"
+        if [[ "$FAST_MODEL" != "$HEAVY_MODEL" ]]; then
+            ollama pull "$HEAVY_MODEL" || fail "Could not pull $HEAVY_MODEL"
+        fi
+    fi
+
+    check "Fast model present: $FAST_MODEL"  "curl -sf $PROVIDER_URL/api/tags | grep -q '$FAST_MODEL'"
+    check "Heavy model present: $HEAVY_MODEL" "curl -sf $PROVIDER_URL/api/tags | grep -q '$HEAVY_MODEL'"
+else
+    # LM Studio and other OpenAI-compatible providers: just verify the endpoint is up.
+    # Model presence can't be checked reliably via /v1/models on all backends.
+    check "$PROVIDER reachable at $PROVIDER_URL" "curl -sf $PROVIDER_URL/models"
+    info "Model pull skipped ($PROVIDER manages its own models — load $FAST_MODEL in $PROVIDER before running)"
 fi
-
-check "Fast model present: $FAST_MODEL"  "curl -sf $OLLAMA_URL/api/tags | grep -q '$FAST_MODEL'"
-check "Heavy model present: $HEAVY_MODEL" "curl -sf $OLLAMA_URL/api/tags | grep -q '$HEAVY_MODEL'"
 
 # ── Install ───────────────────────────────────────────────────────────────────
 header "Install"
@@ -104,18 +150,19 @@ check ".olw/ created"          "test -d $VAULT_DIR/.olw"
 check "wiki.toml created"      "test -f $VAULT_DIR/wiki.toml"
 check "git repo initialised"   "test -d $VAULT_DIR/.git"
 
-# Override models in wiki.toml
-cat > "$VAULT_DIR/wiki.toml" <<TOML
+# Write provider-appropriate wiki.toml
+if [[ "$PROVIDER" == "ollama" ]]; then
+    cat > "$VAULT_DIR/wiki.toml" <<TOML
 [models]
 fast = "$FAST_MODEL"
 heavy = "$HEAVY_MODEL"
 embed = "nomic-embed-text"
 
 [ollama]
-url = "$OLLAMA_URL"
+url = "$PROVIDER_URL"
 timeout = 900
-fast_ctx = 8192
-heavy_ctx = 16384
+fast_ctx = $FAST_CTX
+heavy_ctx = $HEAVY_CTX
 
 [pipeline]
 auto_approve = false
@@ -127,7 +174,31 @@ chunk_size = 512
 chunk_overlap = 50
 similarity_threshold = 0.7
 TOML
-pass "wiki.toml configured (fast=$FAST_MODEL, heavy=$HEAVY_MODEL)"
+else
+    cat > "$VAULT_DIR/wiki.toml" <<TOML
+[models]
+fast = "$FAST_MODEL"
+heavy = "$HEAVY_MODEL"
+
+[provider]
+name = "$PROVIDER"
+url = "$PROVIDER_URL"
+timeout = 900
+fast_ctx = $FAST_CTX
+heavy_ctx = $HEAVY_CTX
+
+[pipeline]
+auto_approve = false
+auto_commit = true
+watch_debounce = 3.0
+
+[rag]
+chunk_size = 512
+chunk_overlap = 50
+similarity_threshold = 0.7
+TOML
+fi
+pass "wiki.toml configured (provider=$PROVIDER fast=$FAST_MODEL heavy=$HEAVY_MODEL)"
 
 # ── Doctor ───────────────────────────────────────────────────────────────────
 header "olw doctor"
@@ -195,7 +266,7 @@ RAW_HASH_2=$(shasum "$VAULT_DIR/raw/machine-learning-basics.md" | awk '{print $1
 
 # ── Ingest ────────────────────────────────────────────────────────────────────
 header "olw ingest --all"
-info "Calling Ollama ($FAST_MODEL) — may take 30-120s..."
+info "Calling $PROVIDER ($FAST_MODEL) — may take 30-120s..."
 
 $OLW ingest --all 2>&1
 
@@ -257,7 +328,7 @@ fi
 
 # ── Compile (concept-driven) ──────────────────────────────────────────────────
 header "olw compile (concept-driven)"
-info "Calling Ollama ($HEAVY_MODEL) — may take 2-5 min..."
+info "Calling $PROVIDER ($HEAVY_MODEL) — may take 2-5 min..."
 
 $OLW compile 2>&1
 

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -35,6 +35,15 @@ class LLMError(Exception):
     """Base error for all LLM client failures (OllamaError inherits from this)."""
 
 
+class LLMBadRequestError(LLMError):
+    """HTTP 400 from the provider — usually bad input (prompt/context too long, etc.).
+
+    Unlike transient connection or rate-limit errors this is per-request and non-retryable
+    at the pipeline level, so compile_concepts catches it per-concept rather than aborting
+    the whole run.
+    """
+
+
 class OpenAICompatClient:
     def __init__(
         self,
@@ -107,6 +116,8 @@ class OpenAICompatClient:
             return LLMError(f"{prefix}Request timed out ({self._timeout}s). {context}")
         if isinstance(exc, httpx.HTTPStatusError):
             code = exc.response.status_code
+            if code == 400:
+                return LLMBadRequestError(f"{prefix}HTTP {code}: {exc.response.text[:200]}")
             if code == 401:
                 return LLMError(f"{prefix}HTTP 401 Unauthorized. Check your API key.")
             if code == 429:

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -201,10 +201,12 @@ class OpenAICompatClient:
                     "%s: HTTP 400 with response_format, retrying without json mode",
                     self.provider_name,
                 )
-                current_payload = {k: v for k, v in current_payload.items() if k != "response_format"}
+                current_payload = {
+                    k: v for k, v in current_payload.items() if k != "response_format"
+                }
                 resp = self._client.post(self._chat_url(), json=current_payload)
 
-            # Auto-downgrade 2: n_keep > context error (LM Studio / llama.cpp) → retry without max_tokens
+            # Auto-downgrade 2: n_keep > context (LM Studio / llama.cpp) → retry without max_tokens
             if resp.status_code == 400 and "max_tokens" in current_payload:
                 err_text = resp.text.lower()
                 if "tokens to keep" in err_text or "n_keep" in err_text:
@@ -212,7 +214,9 @@ class OpenAICompatClient:
                         "%s: HTTP 400 n_keep error, retrying without max_tokens",
                         self.provider_name,
                     )
-                    current_payload = {k: v for k, v in current_payload.items() if k != "max_tokens"}
+                    current_payload = {
+                        k: v for k, v in current_payload.items() if k != "max_tokens"
+                    }
                     resp = self._client.post(self._chat_url(), json=current_payload)
 
             resp.raise_for_status()

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -190,14 +190,31 @@ class OpenAICompatClient:
 
         try:
             resp = self._client.post(self._chat_url(), json=payload)
-            # Auto-downgrade: if provider rejects response_format, retry without it
+            # Each auto-downgrade strips one unsupported field and retries.
+            # Use current_payload so retries chain (each builds on the previous
+            # stripped payload rather than the original).
+            current_payload = payload
+
+            # Auto-downgrade 1: provider rejects response_format → retry without it
             if resp.status_code == 400 and use_json_mode:
                 log.debug(
                     "%s: HTTP 400 with response_format, retrying without json mode",
                     self.provider_name,
                 )
-                payload_no_json = {k: v for k, v in payload.items() if k != "response_format"}
-                resp = self._client.post(self._chat_url(), json=payload_no_json)
+                current_payload = {k: v for k, v in current_payload.items() if k != "response_format"}
+                resp = self._client.post(self._chat_url(), json=current_payload)
+
+            # Auto-downgrade 2: n_keep > context error (LM Studio / llama.cpp) → retry without max_tokens
+            if resp.status_code == 400 and "max_tokens" in current_payload:
+                err_text = resp.text.lower()
+                if "tokens to keep" in err_text or "n_keep" in err_text:
+                    log.debug(
+                        "%s: HTTP 400 n_keep error, retrying without max_tokens",
+                        self.provider_name,
+                    )
+                    current_payload = {k: v for k, v in current_payload.items() if k != "max_tokens"}
+                    resp = self._client.post(self._chat_url(), json=current_payload)
+
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
             raise self._wrap_error(e) from e

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -26,7 +26,7 @@ import frontmatter as fm_lib
 
 from ..config import Config
 from ..models import ArticlePlan, CompilePlan, SingleArticle, WikiArticleRecord
-from ..openai_compat_client import LLMError
+from ..openai_compat_client import LLMBadRequestError
 from ..protocols import LLMClientProtocol
 from ..sanitize import sanitize_tags
 from ..state import StateDB
@@ -402,9 +402,9 @@ def compile_concepts(
                     model=config.models.fast,
                     system=_STUB_WRITE_SYSTEM,
                     num_ctx=config.effective_provider.fast_ctx,
-                    num_predict=_MAX_STUB_PREDICT,
+                    num_predict=min(_MAX_STUB_PREDICT, config.effective_provider.fast_ctx),
                 )
-            except (StructuredOutputError, LLMError) as e:
+            except (StructuredOutputError, LLMBadRequestError) as e:
                 log.error("Failed to write stub '%s': %s", name, e)
                 failed.append(name)
                 continue
@@ -462,9 +462,9 @@ def compile_concepts(
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
                 num_ctx=config.effective_provider.heavy_ctx,
-                num_predict=_MAX_ARTICLE_PREDICT,
+                num_predict=min(_MAX_ARTICLE_PREDICT, config.effective_provider.heavy_ctx),
             )
-        except (StructuredOutputError, LLMError) as e:
+        except (StructuredOutputError, LLMBadRequestError) as e:
             log.error("Failed to write '%s': %s", name, e)
             failed.append(name)
             continue
@@ -570,7 +570,7 @@ def compile_notes(
             system=_PLAN_SYSTEM,
             num_ctx=config.effective_provider.fast_ctx,
         )
-    except (StructuredOutputError, LLMError) as e:
+    except (StructuredOutputError, LLMBadRequestError) as e:
         log.error("Planning failed: %s", e)
         return [], ["__planning_failed__"]
 
@@ -615,9 +615,9 @@ def compile_notes(
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
                 num_ctx=config.effective_provider.heavy_ctx,
-                num_predict=_MAX_ARTICLE_PREDICT,
+                num_predict=min(_MAX_ARTICLE_PREDICT, config.effective_provider.heavy_ctx),
             )
-        except (StructuredOutputError, LLMError) as e:
+        except (StructuredOutputError, LLMBadRequestError) as e:
             log.error("Failed to write '%s': %s", article.title, e)
             failed.append(article.title)
             continue

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -26,6 +26,7 @@ import frontmatter as fm_lib
 
 from ..config import Config
 from ..models import ArticlePlan, CompilePlan, SingleArticle, WikiArticleRecord
+from ..openai_compat_client import LLMError
 from ..protocols import LLMClientProtocol
 from ..sanitize import sanitize_tags
 from ..state import StateDB
@@ -81,6 +82,14 @@ _BUDGET_OUTPUT = 1800  # room for generated content
 _BUDGET_SAFETY = 200  # buffer
 
 _QUALITY_BONUS = {"high": 0.25, "medium": 0.1, "low": 0.0}
+
+# Max tokens to request for article / stub generation.
+# Real-world articles peak at ~2000 words ≈ 3000 tokens; 4096 gives headroom.
+# Keeping these well below typical model context windows avoids LM Studio's
+# "tokens to keep from initial prompt > context length" error (triggered when
+# max_tokens >= model's loaded n_ctx).
+_MAX_ARTICLE_PREDICT = 4096  # covers ~2700 word articles
+_MAX_STUB_PREDICT = 512  # stubs capped at 150 words ≈ 200 tokens
 
 
 def _content_hash(text: str) -> str:
@@ -393,9 +402,9 @@ def compile_concepts(
                     model=config.models.fast,
                     system=_STUB_WRITE_SYSTEM,
                     num_ctx=config.effective_provider.fast_ctx,
-                    num_predict=config.effective_provider.fast_ctx // 2,
+                    num_predict=_MAX_STUB_PREDICT,
                 )
-            except StructuredOutputError as e:
+            except (StructuredOutputError, LLMError) as e:
                 log.error("Failed to write stub '%s': %s", name, e)
                 failed.append(name)
                 continue
@@ -453,9 +462,9 @@ def compile_concepts(
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
                 num_ctx=config.effective_provider.heavy_ctx,
-                num_predict=config.effective_provider.heavy_ctx // 2,
+                num_predict=_MAX_ARTICLE_PREDICT,
             )
-        except StructuredOutputError as e:
+        except (StructuredOutputError, LLMError) as e:
             log.error("Failed to write '%s': %s", name, e)
             failed.append(name)
             continue
@@ -561,7 +570,7 @@ def compile_notes(
             system=_PLAN_SYSTEM,
             num_ctx=config.effective_provider.fast_ctx,
         )
-    except StructuredOutputError as e:
+    except (StructuredOutputError, LLMError) as e:
         log.error("Planning failed: %s", e)
         return [], ["__planning_failed__"]
 
@@ -606,9 +615,9 @@ def compile_notes(
                 model=config.models.heavy,
                 system=_WRITE_SYSTEM,
                 num_ctx=config.effective_provider.heavy_ctx,
-                num_predict=config.effective_provider.heavy_ctx // 2,
+                num_predict=_MAX_ARTICLE_PREDICT,
             )
-        except StructuredOutputError as e:
+        except (StructuredOutputError, LLMError) as e:
             log.error("Failed to write '%s': %s", article.title, e)
             failed.append(article.title)
             continue

--- a/src/obsidian_llm_wiki/pipeline/orchestrator.py
+++ b/src/obsidian_llm_wiki/pipeline/orchestrator.py
@@ -212,7 +212,7 @@ def _run_compile(
     dry_run: bool,
 ) -> tuple[list[Path], list[FailureRecord], dict[str, float]]:
     """Run compile_concepts and classify failures by reason."""
-    from ..openai_compat_client import LLMError
+    from ..openai_compat_client import LLMBadRequestError, LLMError
     from ..pipeline.compile import compile_concepts
 
     try:
@@ -222,6 +222,18 @@ def _run_compile(
             db=db,
             dry_run=dry_run,
             concepts=concepts,
+        )
+    except LLMBadRequestError as e:
+        # Bad request (HTTP 400) — non-retryable; mark all as UNKNOWN not TRANSIENT
+        log.error("LLM bad request during compile: %s", e)
+        all_concepts = concepts or db.concepts_needing_compile()
+        return (
+            [],
+            [
+                FailureRecord(concept=c, reason=FailureReason.UNKNOWN, error_msg=str(e))
+                for c in all_concepts
+            ],
+            {},
         )
     except LLMError as e:
         # Connection-level failure — all concepts are transient

--- a/tests/test_compile_v2.py
+++ b/tests/test_compile_v2.py
@@ -381,3 +381,34 @@ def test_compile_concepts_stub_failure_adds_to_failed(config, db):
 
     drafts, failed, _ = compile_concepts(config, client, db)
     assert "Bad Stub" in failed
+
+
+def test_compile_concepts_stub_llm_bad_request_adds_to_failed(config, db):
+    """LLMBadRequestError during stub compile → concept in failed, no crash."""
+    from obsidian_llm_wiki.openai_compat_client import LLMBadRequestError
+
+    db.add_stub("Context Overflow Stub")
+    client = make_mock_client()
+    client.generate.side_effect = LLMBadRequestError("HTTP 400: context too long")
+
+    drafts, failed, _ = compile_concepts(config, client, db)
+    assert "Context Overflow Stub" in failed
+    assert drafts == []
+
+
+def test_compile_concepts_article_llm_bad_request_adds_to_failed(config, db):
+    """LLMBadRequestError during article compile → concept in failed, no crash."""
+    from obsidian_llm_wiki.openai_compat_client import LLMBadRequestError
+
+    db.upsert_raw(RawNoteRecord(path="raw/src.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/src.md", ["Heavy Concept"])
+    (config.vault / "raw" / "src.md").write_text(
+        "---\ntitle: Source\n---\nContent about Heavy Concept."
+    )
+
+    client = make_mock_client()
+    client.generate.side_effect = LLMBadRequestError("HTTP 400: n_keep > ctx")
+
+    drafts, failed, _ = compile_concepts(config, client, db)
+    assert "Heavy Concept" in failed
+    assert drafts == []

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -125,6 +125,30 @@ def test_run_compile_unknown_failure_per_concept(config, db):
     assert failures[0].concept == "Fails"
 
 
+def test_run_compile_bad_request_not_transient(config, db):
+    """LLMBadRequestError from compile_concepts → UNKNOWN, not TRANSIENT (non-retryable)."""
+    import obsidian_llm_wiki.pipeline.compile as compile_mod
+    from obsidian_llm_wiki.openai_compat_client import LLMBadRequestError
+
+    original = compile_mod.compile_concepts
+
+    def raise_bad_request(**kwargs):
+        raise LLMBadRequestError("HTTP 400: context too long")
+
+    compile_mod.compile_concepts = raise_bad_request
+    try:
+        drafts, failures, _ = _run_compile(
+            config, make_mock_client(), db, concepts=["Huge"], dry_run=False
+        )
+    finally:
+        compile_mod.compile_concepts = original
+
+    assert drafts == []
+    assert len(failures) == 1
+    assert failures[0].concept == "Huge"
+    assert failures[0].reason == FailureReason.UNKNOWN  # not TRANSIENT — do not retry
+
+
 # ── PipelineOrchestrator.run ──────────────────────────────────────────────────
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from obsidian_llm_wiki.openai_compat_client import LLMError, OpenAICompatClient
+from obsidian_llm_wiki.openai_compat_client import LLMBadRequestError, LLMError, OpenAICompatClient
 from obsidian_llm_wiki.providers import (
     get_provider,
     list_all_providers,
@@ -195,6 +195,107 @@ def test_generate_connect_error_raises_llmerror():
     with patch.object(client._client, "post", side_effect=httpx.ConnectError("refused")):
         with pytest.raises(LLMError, match="Cannot connect"):
             client.generate("p", model="m")
+
+
+def test_generate_400_raises_llm_bad_request_error():
+    """HTTP 400 is wrapped as LLMBadRequestError, not the generic LLMError."""
+    client = _make_client(supports_json_mode=False)
+    bad_resp = MagicMock()
+    bad_resp.status_code = 400
+    bad_resp.text = '{"error":"bad input"}'
+    bad_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=bad_resp
+    )
+    with patch.object(client._client, "post", return_value=bad_resp):
+        with pytest.raises(LLMBadRequestError):
+            client.generate("p", model="m")
+
+
+def test_generate_nkeep_400_retry_strips_max_tokens():
+    """On 400 'tokens to keep' error, client retries without max_tokens."""
+    client = _make_client(supports_json_mode=False)
+
+    nkeep_resp = MagicMock()
+    nkeep_resp.status_code = 400
+    nkeep_resp.text = '{"error":"The number of tokens to keep from the initial prompt is greater"}'
+    nkeep_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=nkeep_resp
+    )
+
+    good_resp = MagicMock()
+    good_resp.status_code = 200
+    good_resp.raise_for_status.return_value = None
+    good_resp.json.return_value = {"choices": [{"message": {"content": "ok"}}]}
+
+    payloads = []
+
+    def fake_post(url, json=None, **kw):
+        payloads.append(json)
+        return nkeep_resp if len(payloads) == 1 else good_resp
+
+    with patch.object(client._client, "post", side_effect=fake_post):
+        result = client.generate("p", model="m", num_predict=4096)
+
+    assert result == "ok"
+    assert len(payloads) == 2
+    assert "max_tokens" in payloads[0]
+    assert "max_tokens" not in payloads[1]
+
+
+def test_generate_chained_response_format_then_nkeep():
+    """Chained: first 400 strips response_format, second 400 strips max_tokens.
+    The final retry must not reintroduce response_format."""
+    client = _make_client(supports_json_mode=True)
+
+    rf_resp = MagicMock()
+    rf_resp.status_code = 400
+    rf_resp.text = '{"error":"response_format.type must be json_schema or text"}'
+    rf_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=rf_resp
+    )
+
+    nkeep_resp = MagicMock()
+    nkeep_resp.status_code = 400
+    nkeep_resp.text = '{"error":"tokens to keep exceeds context length"}'
+    nkeep_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "400", request=MagicMock(), response=nkeep_resp
+    )
+
+    good_resp = MagicMock()
+    good_resp.status_code = 200
+    good_resp.raise_for_status.return_value = None
+    good_resp.json.return_value = {"choices": [{"message": {"content": "done"}}]}
+
+    call_count = {"n": 0}
+
+    def fake_post(url, json=None, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return rf_resp    # has response_format + max_tokens → 400 rf error
+        if call_count["n"] == 2:
+            return nkeep_resp  # has max_tokens, no response_format → 400 nkeep
+        return good_resp       # no response_format, no max_tokens → 200
+
+    payloads = []
+
+    def capturing_post(url, json=None, **kw):
+        payloads.append(json)
+        return fake_post(url, json=json, **kw)
+
+    with patch.object(client._client, "post", side_effect=capturing_post):
+        result = client.generate("p", model="m", format="json", num_predict=4096)
+
+    assert result == "done"
+    assert call_count["n"] == 3
+    # First request: has both fields
+    assert "response_format" in payloads[0]
+    assert "max_tokens" in payloads[0]
+    # Second request (after rf downgrade): no response_format, still has max_tokens
+    assert "response_format" not in payloads[1]
+    assert "max_tokens" in payloads[1]
+    # Third request (after nkeep downgrade): neither field
+    assert "response_format" not in payloads[2]
+    assert "max_tokens" not in payloads[2]
 
 
 def test_generate_timeout_raises_llmerror():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -271,10 +271,10 @@ def test_generate_chained_response_format_then_nkeep():
     def fake_post(url, json=None, **kw):
         call_count["n"] += 1
         if call_count["n"] == 1:
-            return rf_resp    # has response_format + max_tokens → 400 rf error
+            return rf_resp  # has response_format + max_tokens → 400 rf error
         if call_count["n"] == 2:
             return nkeep_resp  # has max_tokens, no response_format → 400 nkeep
-        return good_resp       # no response_format, no max_tokens → 200
+        return good_resp  # no response_format, no max_tokens → 200
 
     payloads = []
 

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Fix LM Studio HTTP 400 context-length errors during compile by capping output tokens (`_MAX_ARTICLE_PREDICT=4096`, `_MAX_STUB_PREDICT=512`) — prevents `max_tokens > model n_ctx`
- Chain `response_format` + `n_keep` auto-downgrades in `openai_compat_client` via `current_payload` so retries don't re-introduce already-stripped fields
- Catch `LLMError` per-concept in compile pipeline so one oversized source marks only that concept as failed instead of crashing the entire run
- `smoke_test.sh`: add `PROVIDER=lm_studio` support with per-provider defaults (URL, model names, context sizes, `wiki.toml` format)

## Test plan

- [x] Unit tests: `uv run pytest` — 373 passed
- [x] LM Studio smoke test: `PROVIDER=lm_studio bash scripts/smoke_test.sh` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)