### PR TITLE
fix: suppress Python warnings in smoke_test YAML checks

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -289,18 +289,29 @@ if [[ "$SOURCE_COUNT" -gt 0 ]]; then
     check "source page has tags: [source]"    "grep -q 'source' \"$FIRST_SOURCE\""
     check "source page has concept wikilinks" "grep -q '\[\[' \"$FIRST_SOURCE\""
 
-    SRC_YAML_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>&1 <<'PYEOF'
+    SRC_YAML_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-frontmatter.load(sys.argv[1])
+try:
+    frontmatter.load(sys.argv[1])
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "source page YAML is parseable" "test -z \"$SRC_YAML_ERR\""
 
-    SRC_ALIAS_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>&1 <<'PYEOF'
+    SRC_ALIAS_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-m = frontmatter.load(sys.argv[1])
-aliases = m.get('aliases', [])
-assert isinstance(aliases, list), f'aliases not a list: {aliases!r}'
+try:
+    m = frontmatter.load(sys.argv[1])
+    aliases = m.get('aliases', [])
+    assert isinstance(aliases, list), f'aliases not a list: {aliases!r}'
+except AssertionError as e:
+    print(str(e))
+    sys.exit(1)
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "source page aliases is a list" "test -z \"$SRC_ALIAS_ERR\""
@@ -345,13 +356,17 @@ if [[ "$DRAFT_COUNT" -gt 0 ]]; then
     check "draft has content"            "test \$(wc -l < \"$FIRST_DRAFT\") -ge 10"
     check "draft has ## Sources section" "grep -q '^## Sources' \"$FIRST_DRAFT\""
     check "draft has confidence field"   "grep -q 'confidence:' \"$FIRST_DRAFT\""
-    DRAFT_YAML_OK=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>&1 <<'PYEOF'
+    DRAFT_YAML_OK=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-frontmatter.load(sys.argv[1])
+try:
+    frontmatter.load(sys.argv[1])
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "draft YAML is parseable" "test -z \"$DRAFT_YAML_OK\""
-    DRAFT_TAG_BAD=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>&1 <<'PYEOF'
+    DRAFT_TAG_BAD=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
 import sys, re, frontmatter
 m = frontmatter.load(sys.argv[1])
 valid_re = re.compile(r'^[a-z0-9][a-zA-Z0-9_/\-]*$')


### PR DESCRIPTION
## Summary

- YAML parseable checks in `smoke_test.sh` used `2>&1` to capture output, so any Python deprecation warnings (e.g. from `python-frontmatter`) landed in the variable and made `test -z` fail even when YAML was valid
- Switch to `2>/dev/null` + `try/except` so only real parse errors are printed to stdout; warnings are silenced

## Root cause

Background smoke test (LM Studio run) failed at `draft YAML is parseable` despite 15/15 drafts compiling successfully. The `frontmatter.load()` call emits a warning to stderr that was captured by `2>&1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)