### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### New Features
 
-- **Multi-language support** — `olw ingest` detects the language of each note and stores it. `olw compile` then writes each article in the appropriate language: the detected language if all sources agree, the vault-wide `language` setting from `wiki.toml` if configured, or English as a fallback. French notes produce French articles, Japanese notes produce Japanese articles, and so on.
+- **Multi-language support** — `olw ingest` detects the language of each note and stores it. `olw compile` then writes each article in the appropriate language: the detected language if all sources agree, or the vault-wide `language` setting from `wiki.toml` if configured. French notes produce French articles, Japanese notes produce Japanese articles, and so on.
 
-- **`olw review --reject-all`** — Reject every pending draft in one step with a shared feedback message. Useful when a bad prompt version or wrong model produced a full batch of unusable drafts.
+- **`olw reject --all`** — Reject every pending draft in one step with a shared feedback message. Useful when a bad prompt version or wrong model produced a full batch of unusable drafts.
 
 - **Vault auto-detection** — Commands no longer fail when `--vault` is not passed and no default was saved in `olw setup`. If you're inside a vault directory (or any subdirectory), `olw` finds it automatically by walking up to the nearest `wiki.toml`. The "press Enter to skip" flow in setup now actually makes sense.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.4.0] - 2026-04-16
+
+### Highlights
+
+**v0.4 makes `olw` smarter about where you are and what you're writing.** Notes are now analyzed in the language they were written in, and articles are compiled in the same language — no more English-only output in a multilingual vault. You can also reject an entire batch of drafts in one go. Two usability papercuts are fixed: the tool now finds your vault automatically when you're already inside it, and the review menu works correctly in all terminals.
+
+### New Features
+
+- **Multi-language support** — `olw ingest` detects the language of each note and stores it. `olw compile` then writes each article in the appropriate language: the detected language if all sources agree, the vault-wide `language` setting from `wiki.toml` if configured, or English as a fallback. French notes produce French articles, Japanese notes produce Japanese articles, and so on.
+
+- **`olw review --reject-all`** — Reject every pending draft in one step with a shared feedback message. Useful when a bad prompt version or wrong model produced a full batch of unusable drafts.
+
+- **Vault auto-detection** — Commands no longer fail when `--vault` is not passed and no default was saved in `olw setup`. If you're inside a vault directory (or any subdirectory), `olw` finds it automatically by walking up to the nearest `wiki.toml`. The "press Enter to skip" flow in setup now actually makes sense.
+
+### Bug Fixes
+
+- **Review menu shortcuts were invisible in some terminals** — The `olw review` action menu (`[a]pprove`, `[r]eject`, etc.) used Rich markup that silently ate the first letter of each word in terminals with limited style support, showing `pprove eject dit` instead. Prompts now render as plain text (`a=approve, r=reject, e=edit, ...`) and work correctly everywhere.
+
 ## [0.3.0] - 2026-04-15
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The wiki lives in Obsidian, so you get the graph view, backlinks, and Dataview q
 - **Wiki health checks** — `olw lint` detects orphans, broken links, stale articles (no LLM needed)
 - **Query your wiki** — `olw query "what is X?"` answers from your published articles
 - **Git safety net** — every auto-action is committed; `olw undo` reverts safely
+- **Multi-language** — automatically detects the language of each note at ingest time; articles are written in the detected language; override globally with `language = "en"` in `wiki.toml`
 - **Multi-provider** — swap Ollama for Groq, Together AI, LM Studio, vLLM, Azure OpenAI, or any OpenAI-compatible endpoint via `olw setup`
 - **Offline test suite** — all 373 tests run without Ollama or any provider
 
@@ -207,6 +208,27 @@ raw/note.md
 
 ---
 
+## Multi-language support
+
+`olw` detects the language of each raw note during ingest and stores it. At compile time, the article is written in that language — no configuration needed.
+
+**How it works:**
+
+1. **Ingest** — the fast model detects the primary language and stores an ISO 639-1 code (`en`, `fr`, `de`, …) per note in the state DB.
+2. **Compile** — when all source notes for a concept share the same language, the heavy model is instructed to write the article in that language. If sources are mixed, it falls back to matching the source text.
+3. **Config override** — set `language` in `wiki.toml` to force a specific output language for the whole vault, regardless of what the model detected.
+
+```toml
+[pipeline]
+language = "fr"   # all articles will be written in French
+```
+
+Leave `language` unset (the default) to let auto-detection drive it per concept.
+
+**Example:** a French note ingested alongside English notes produces a French article for French-only concepts and an English article for concepts sourced from English notes. Setting `language = "en"` forces everything to English.
+
+---
+
 ## Rejection feedback loop
 
 The core v0.2 feature. When you reject a draft:
@@ -308,6 +330,7 @@ auto_maintain = false            # true = run maintain checks after each compile
 max_concepts_per_source = 8      # limit concepts extracted per note
 watch_debounce = 3.0             # seconds after last file event before processing
 ingest_parallel = false          # true = parallel chunk analysis (needs OLLAMA_NUM_PARALLEL>=4)
+# language = "en"               # ISO 639-1 output language; autodetects from notes if unset
 ```
 
 > **API keys** are never stored in `wiki.toml`. They are read at runtime from the provider-specific env var (e.g. `GROQ_API_KEY`), the generic `OLW_API_KEY` env var, or the `api_key` field in `~/.config/olw/config.toml` (written by `olw setup`).
@@ -371,6 +394,8 @@ After editing `wiki.toml`, no reinstall is needed. Run `olw compile --force` to 
 | `olw approve FILE` | Publish one draft |
 | `olw reject FILE` | Discard a draft (prompts for feedback) |
 | `olw reject FILE --feedback "..."` | Discard with feedback for next compile |
+| `olw reject --all` | Discard all drafts (prompts once for shared feedback) |
+| `olw reject --all --feedback "..."` | Discard all drafts with feedback |
 | `olw unblock "Concept"` | Re-enable a concept blocked after 5 rejections |
 | `olw maintain` | Health check + stubs + orphan and merge suggestions |
 | `olw maintain --fix` | Auto-fix issues and create stub articles |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-llm-wiki"
-version = "0.3.1"
+version = "0.4.0"
 description = "Convert Obsidian notes into an AI-maintained wiki using local or cloud LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -289,18 +289,29 @@ if [[ "$SOURCE_COUNT" -gt 0 ]]; then
     check "source page has tags: [source]"    "grep -q 'source' \"$FIRST_SOURCE\""
     check "source page has concept wikilinks" "grep -q '\[\[' \"$FIRST_SOURCE\""
 
-    SRC_YAML_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>&1 <<'PYEOF'
+    SRC_YAML_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-frontmatter.load(sys.argv[1])
+try:
+    frontmatter.load(sys.argv[1])
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "source page YAML is parseable" "test -z \"$SRC_YAML_ERR\""
 
-    SRC_ALIAS_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>&1 <<'PYEOF'
+    SRC_ALIAS_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-m = frontmatter.load(sys.argv[1])
-aliases = m.get('aliases', [])
-assert isinstance(aliases, list), f'aliases not a list: {aliases!r}'
+try:
+    m = frontmatter.load(sys.argv[1])
+    aliases = m.get('aliases', [])
+    assert isinstance(aliases, list), f'aliases not a list: {aliases!r}'
+except AssertionError as e:
+    print(str(e))
+    sys.exit(1)
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "source page aliases is a list" "test -z \"$SRC_ALIAS_ERR\""
@@ -345,13 +356,17 @@ if [[ "$DRAFT_COUNT" -gt 0 ]]; then
     check "draft has content"            "test \$(wc -l < \"$FIRST_DRAFT\") -ge 10"
     check "draft has ## Sources section" "grep -q '^## Sources' \"$FIRST_DRAFT\""
     check "draft has confidence field"   "grep -q 'confidence:' \"$FIRST_DRAFT\""
-    DRAFT_YAML_OK=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>&1 <<'PYEOF'
+    DRAFT_YAML_OK=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
 import sys, frontmatter
-frontmatter.load(sys.argv[1])
+try:
+    frontmatter.load(sys.argv[1])
+except Exception as e:
+    print(f"error: {e}")
+    sys.exit(1)
 PYEOF
 )
     check "draft YAML is parseable" "test -z \"$DRAFT_YAML_OK\""
-    DRAFT_TAG_BAD=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>&1 <<'PYEOF'
+    DRAFT_TAG_BAD=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
 import sys, re, frontmatter
 m = frontmatter.load(sys.argv[1])
 valid_re = re.compile(r'^[a-z0-9][a-zA-Z0-9_/\-]*$')

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -338,6 +338,33 @@ if [[ "$SOURCE_COUNT" -gt 0 ]]; then
     check "source pages have concept wikilinks" "test '$CONCEPT_LINKS' -ge 1"
 fi
 
+# ── Language detection check ──────────────────────────────────────────────────
+header "Language detection (ingest)"
+
+cat > "$VAULT_DIR/raw/note-francais.md" <<'EOF'
+---
+title: Apprentissage automatique
+---
+
+L'apprentissage automatique est une branche de l'intelligence artificielle.
+Les algorithmes apprennent à partir des données sans être explicitement programmés.
+
+Les principales approches sont l'apprentissage supervisé, non supervisé et par renforcement.
+EOF
+
+$OLW ingest "$VAULT_DIR/raw/note-francais.md" 2>&1
+
+LANG_IN_DB=$(python3 - <<PYEOF
+import sqlite3
+conn = sqlite3.connect("$VAULT_DIR/.olw/state.db")
+row = conn.execute("SELECT language FROM raw_notes WHERE path='raw/note-francais.md'").fetchone()
+print(row[0] if row else "")
+conn.close()
+PYEOF
+)
+check "language column populated after ingest" "test -n \"$LANG_IN_DB\""
+info "Detected language: '$LANG_IN_DB'"
+
 # ── Compile (concept-driven) ──────────────────────────────────────────────────
 header "olw compile (concept-driven)"
 info "Calling $PROVIDER ($HEAVY_MODEL) — may take 2-5 min..."

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -290,8 +290,9 @@ if [[ "$SOURCE_COUNT" -gt 0 ]]; then
     check "source page has concept wikilinks" "grep -q '\[\[' \"$FIRST_SOURCE\""
 
     SRC_YAML_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
-import sys, frontmatter
+import sys
 try:
+    import frontmatter
     frontmatter.load(sys.argv[1])
 except Exception as e:
     print(f"error: {e}")
@@ -301,8 +302,9 @@ PYEOF
     check "source page YAML is parseable" "test -z \"$SRC_YAML_ERR\""
 
     SRC_ALIAS_ERR=$(uv run --project "$REPO_DIR" python - "$FIRST_SOURCE" 2>/dev/null <<'PYEOF'
-import sys, frontmatter
+import sys
 try:
+    import frontmatter
     m = frontmatter.load(sys.argv[1])
     aliases = m.get('aliases', [])
     assert isinstance(aliases, list), f'aliases not a list: {aliases!r}'
@@ -384,8 +386,9 @@ if [[ "$DRAFT_COUNT" -gt 0 ]]; then
     check "draft has ## Sources section" "grep -q '^## Sources' \"$FIRST_DRAFT\""
     check "draft has confidence field"   "grep -q 'confidence:' \"$FIRST_DRAFT\""
     DRAFT_YAML_OK=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
-import sys, frontmatter
+import sys
 try:
+    import frontmatter
     frontmatter.load(sys.argv[1])
 except Exception as e:
     print(f"error: {e}")
@@ -394,12 +397,17 @@ PYEOF
 )
     check "draft YAML is parseable" "test -z \"$DRAFT_YAML_OK\""
     DRAFT_TAG_BAD=$(uv run --project "$REPO_DIR" python - "$FIRST_DRAFT" 2>/dev/null <<'PYEOF'
-import sys, re, frontmatter
-m = frontmatter.load(sys.argv[1])
-valid_re = re.compile(r'^[a-z0-9][a-zA-Z0-9_/\-]*$')
-bad = [t for t in m.get('tags', []) if not isinstance(t, str) or ' ' in t or t != t.lower() or not valid_re.match(t)]
-if bad:
-    print(f"Bad tags: {bad}")
+import sys
+try:
+    import re, frontmatter
+    m = frontmatter.load(sys.argv[1])
+    valid_re = re.compile(r'^[a-z0-9][a-zA-Z0-9_/\-]*$')
+    bad = [t for t in m.get('tags', []) if not isinstance(t, str) or ' ' in t or t != t.lower() or not valid_re.match(t)]
+    if bad:
+        print(f"Bad tags: {bad}")
+        sys.exit(1)
+except Exception as e:
+    print(f"error: {e}")
     sys.exit(1)
 PYEOF
 )

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -861,44 +861,65 @@ def approve(vault_str, approve_all, files):
 
 @cli.command()
 @click.option("--vault", "vault_str", envvar="OLW_VAULT", default=None)
+@click.option("--all", "reject_all", is_flag=True, help="Reject all drafts in wiki/.drafts/")
 @click.option("--feedback", default="", help="Reason for rejection")
-@click.argument("file", type=click.Path(exists=True))
-def reject(vault_str, feedback, file):
-    """Discard a draft article and store rejection feedback for future recompiles."""
+@click.argument("files", nargs=-1, type=click.Path())
+def reject(vault_str, reject_all, feedback, files):
+    """Discard draft article(s) and store rejection feedback for future recompiles."""
     from .pipeline.compile import reject_draft
 
     config = _load_config(vault_str)
     db = _load_db(config)
 
-    if not feedback:
-        feedback = click.prompt("Reason for rejection?", default="")
+    if reject_all:
+        draft_paths = (
+            list(config.drafts_dir.rglob("*.md")) if config.drafts_dir.exists() else []
+        )
+        if not draft_paths:
+            console.print("[yellow]No drafts to reject.[/yellow]")
+            return
+        if not feedback:
+            feedback = click.prompt("Reason for rejecting all drafts?", default="")
+    elif files:
+        draft_paths = [Path(f).resolve() for f in files]
+        for p in draft_paths:
+            if not p.exists():
+                click.echo(f"File not found: {p}", err=True)
+                sys.exit(1)
+        if not feedback:
+            feedback = click.prompt("Reason for rejection?", default="")
+    else:
+        click.echo("Specify --all or provide file paths.", err=True)
+        sys.exit(1)
 
-    draft_path = Path(file)
-    # Peek at title before rejection (for user-facing message)
-    title = draft_path.stem
-    try:
-        from .vault import parse_note as _parse
+    from .vault import parse_note as _parse
 
-        meta, _ = _parse(draft_path)
-        title = meta.get("title", draft_path.stem)
-    except Exception:
-        pass
+    for draft_path in draft_paths:
+        title = draft_path.stem
+        try:
+            meta, _ = _parse(draft_path)
+            title = meta.get("title", draft_path.stem)
+        except Exception:
+            pass
 
-    reject_draft(draft_path, config, db, feedback=feedback)
-    console.print(f"[yellow]Draft rejected:[/yellow] {file}")
+        reject_draft(draft_path, config, db, feedback=feedback)
+        console.print(f"[yellow]Draft rejected:[/yellow] {draft_path.name}")
 
-    if feedback:
-        count = db.rejection_count(title)
-        if db.is_concept_blocked(title):
-            console.print(
-                f"[red]⚠ '{title}' blocked after {count} rejections. "
-                f'Use [bold]olw unblock "{title}"[/bold] to re-enable.[/red]'
-            )
-        else:
-            console.print(
-                f"[dim]Feedback saved. Next compile of '{title}' will address it. "
-                f"({count}/{db._REJECTION_CAP} rejections)[/dim]"
-            )
+        if feedback:
+            count = db.rejection_count(title)
+            if db.is_concept_blocked(title):
+                console.print(
+                    f"[red]⚠ '{title}' blocked after {count} rejections. "
+                    f'Use [bold]olw unblock "{title}"[/bold] to re-enable.[/red]'
+                )
+            else:
+                console.print(
+                    f"[dim]Feedback saved. Next compile of '{title}' will address it. "
+                    f"({count}/{db._REJECTION_CAP} rejections)[/dim]"
+                )
+
+    if len(draft_paths) > 1:
+        console.print(f"[green]Rejected {len(draft_paths)} draft(s).[/green]")
 
 
 # ── status ────────────────────────────────────────────────────────────────────

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -42,8 +42,16 @@ def _load_config(vault_str: str | None, **kwargs):
         vault_str = gcfg.vault if gcfg and gcfg.vault else None
 
     if not vault_str:
+        cwd = Path.cwd()
+        for parent in [cwd, *cwd.parents]:
+            if (parent / "wiki.toml").exists():
+                vault_str = str(parent)
+                break
+
+    if not vault_str:
         click.echo(
-            "Error: no vault specified. Use --vault, set OLW_VAULT, or run `olw setup`.",
+            "Error: no vault specified. Use --vault, set OLW_VAULT, run `olw setup`, "
+            "or cd into a vault directory.",
             err=True,
         )
         sys.exit(1)
@@ -872,9 +880,7 @@ def reject(vault_str, reject_all, feedback, files):
     db = _load_db(config)
 
     if reject_all:
-        draft_paths = (
-            list(config.drafts_dir.rglob("*.md")) if config.drafts_dir.exists() else []
-        )
+        draft_paths = list(config.drafts_dir.rglob("*.md")) if config.drafts_dir.exists() else []
         if not draft_paths:
             console.print("[yellow]No drafts to reject.[/yellow]")
             return
@@ -1386,7 +1392,7 @@ def review(vault_str):
             )
 
         console.print(table)
-        console.print("\n[dim]  [a] approve all  [x] reject all  [q] quit  or enter number[/dim]")
+        console.print("\n[dim]  Type: number=open draft, a=approve all, x=reject all, q=quit[/dim]")
         choice = click.prompt("\nChoice", prompt_suffix=" > ").strip().lower()
 
         if choice == "q":
@@ -1473,9 +1479,10 @@ def _review_single(
         # Show body
         console.print(Panel(body[:3000] + ("…" if len(body) > 3000 else ""), title="Draft"))
 
-        console.print("\n[dim]Actions:[/dim]")
-        console.print("[dim]  [a]pprove  [r]eject  [e]dit[/dim]")
-        console.print("[dim]  [d]iff vs published  [v]iew rejection diff  [s]kip[/dim]")
+        console.print(
+            "\n[dim]Type: a=approve, r=reject, e=edit, "
+            "d=diff vs published, v=rejection diff, s=skip[/dim]"
+        )
         raw_action = click.prompt("\nAction", prompt_suffix=" > ").strip()
         action = raw_action.lower()
 

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -68,7 +68,7 @@ def default_wiki_toml(
         f"watch_debounce = 3.0\n"
         f"max_concepts_per_source = 8\n"
         f"ingest_parallel = false   # true = parallel chunks\n"
-        f"# language = \"en\"  # ISO 639-1 output language; autodetects from notes if unset\n"
+        f'# language = "en"  # ISO 639-1 output language; autodetects from notes if unset\n'
     )
 
 

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -68,6 +68,7 @@ def default_wiki_toml(
         f"watch_debounce = 3.0\n"
         f"max_concepts_per_source = 8\n"
         f"ingest_parallel = false   # true = parallel chunks\n"
+        f"# language = \"en\"  # ISO 639-1 output language; autodetects from notes if unset\n"
     )
 
 
@@ -102,6 +103,7 @@ class PipelineConfig(BaseModel):
     max_concepts_per_source: int = 8
     auto_maintain: bool = False
     ingest_parallel: bool = False  # parallel chunk analysis (needs OLLAMA_NUM_PARALLEL≥4)
+    language: str | None = None  # ISO 639-1 output language; autodetects from notes if unset
 
 
 class RagConfig(BaseModel):

--- a/src/obsidian_llm_wiki/models.py
+++ b/src/obsidian_llm_wiki/models.py
@@ -29,6 +29,10 @@ class AnalysisResult(BaseModel):
     quality: Literal["high", "medium", "low"] = Field(
         description="Source quality: high=well-structured, medium=usable, low=noise"
     )
+    language: str | None = Field(
+        default=None,
+        description="ISO 639-1 language code of the note (e.g. 'en', 'fr', 'de'). Null if uncertain.",  # noqa: E501
+    )
 
 
 class ArticlePlan(BaseModel):
@@ -127,6 +131,7 @@ class RawNoteRecord(BaseModel):
     status: Literal["new", "ingested", "compiled", "failed"] = "new"
     summary: str | None = None
     quality: str | None = None
+    language: str | None = None
     ingested_at: datetime | None = None
     compiled_at: datetime | None = None
     error: str | None = None

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -50,7 +50,8 @@ _ANNOTATION_MIN_SOURCES = 2
 
 _STUB_WRITE_SYSTEM = (
     "You are a wiki editor. Write a brief stub article for a wiki concept that was referenced "
-    "by other articles but has no source material yet. Keep it under 150 words. Be factual."
+    "by other articles but has no source material yet. Keep it under 150 words. Be factual. "
+    "Write in the same language as the surrounding wiki content."
 )
 
 _PLAN_SYSTEM = (
@@ -73,6 +74,14 @@ def _load_vault_schema(config: Config) -> str:
         except Exception:
             pass
     return ""
+
+
+def _resolve_language(sources: list[str], db: StateDB, config: Config) -> str | None:
+    """Return output language: config wins; else use detected if all sources agree."""
+    if config.pipeline.language:
+        return config.pipeline.language
+    langs = {db.get_note_language(s) for s in sources} - {None}
+    return langs.pop() if len(langs) == 1 else None
 
 
 # Token budget constants
@@ -282,13 +291,20 @@ def _write_concept_prompt(
     existing_content: str = "",
     vault_schema: str = "",
     rejection_history: list[str] | None = None,
+    language: str | None = None,
 ) -> str:
     titles_str = ", ".join(existing_titles[:50]) if existing_titles else "none yet"
+    lang_instruction = (
+        f"Output language: {language} (ISO 639-1).\n"
+        if language
+        else "Write in the same language as the source notes.\n"
+    )
     prompt = f'Write the wiki article: "{concept}"\n'
     if vault_schema:
         prompt += f"\nVAULT CONVENTIONS:\n{vault_schema}\n"
     prompt += (
-        f"\nIMPORTANT: Keep the content field under 800 words. Be concise.\n"
+        f"\n{lang_instruction}"
+        f"IMPORTANT: Keep the content field under 800 words. Be concise.\n"
         f"Tags must be lowercase, hyphen-separated, no spaces or special characters. "
         f"Good: machine-learning, quantum-computing. Bad: Machine Learning, C++.\n"
         f"Do NOT use inline hashtags (#tag) in the content body — use [[wikilinks]] only.\n"
@@ -450,8 +466,15 @@ def compile_concepts(
             [r["feedback"] for r in rejection_records] if rejection_records else None
         )
 
+        lang = _resolve_language([str(p) for p in resolved_paths], db, config)
         write_prompt = _write_concept_prompt(
-            name, sources_text, existing_titles, existing_content, vault_schema, rejection_history
+            name,
+            sources_text,
+            existing_titles,
+            existing_content,
+            vault_schema,
+            rejection_history,
+            language=lang,
         )
 
         try:
@@ -506,12 +529,23 @@ def _plan_prompt(
     )
 
 
-def _write_prompt_legacy(article: ArticlePlan, sources: str, existing_titles: list[str]) -> str:
+def _write_prompt_legacy(
+    article: ArticlePlan,
+    sources: str,
+    existing_titles: list[str],
+    language: str | None = None,
+) -> str:
     titles_str = ", ".join(existing_titles[:50]) if existing_titles else "none yet"
+    lang_instruction = (
+        f"Output language: {language} (ISO 639-1).\n"
+        if language
+        else "Write in the same language as the source notes.\n"
+    )
     return (
         f'Write the wiki article: "{article.title}"\n'
         f"Action: {article.action}\n"
         f"Reasoning: {article.reasoning}\n"
+        f"{lang_instruction}"
         f"IMPORTANT: Keep the content field under 800 words. Be concise.\n"
         f"Tags must be lowercase, hyphen-separated, no spaces or special characters. "
         f"Good: machine-learning, quantum-computing. Bad: Machine Learning, C++.\n"
@@ -605,7 +639,8 @@ def compile_notes(
             max_chars=config.effective_provider.heavy_ctx // 2,
         )
 
-        write_prompt = _write_prompt_legacy(article, sources_text, existing_titles)
+        lang = _resolve_language([str(p) for p in resolved_paths], db, config)
+        write_prompt = _write_prompt_legacy(article, sources_text, existing_titles, language=lang)
 
         try:
             result: SingleArticle = request_structured(

--- a/src/obsidian_llm_wiki/pipeline/ingest.py
+++ b/src/obsidian_llm_wiki/pipeline/ingest.py
@@ -30,7 +30,9 @@ log = logging.getLogger(__name__)
 
 _SYSTEM = (
     "You are a knowledge analyst. Read the provided note and extract structured information. "
-    "Be concise and accurate. Do not invent information not present in the note."
+    "Be concise and accurate. Do not invent information not present in the note. "
+    "Detect the primary language of the note and return its ISO 639-1 code in the 'language' field "
+    "(e.g. 'en', 'fr', 'de'). Use null if uncertain."
 )
 
 
@@ -82,11 +84,15 @@ def _merge_chunk_results(results: list[AnalysisResult]) -> AnalysisResult:
     quality_rank = {"high": 2, "medium": 1, "low": 0}
     min_result = min(results, key=lambda r: quality_rank.get(r.quality, 1))
 
+    # Use the first non-None detected language across chunks
+    merged_language = next((r.language for r in results if r.language), None)
+
     return AnalysisResult(
         summary=results[0].summary,
         key_concepts=all_concepts[:8],
         suggested_topics=all_topics[:5],
         quality=min_result.quality,
+        language=merged_language,
     )
 
 
@@ -369,6 +375,7 @@ def ingest_note(
             status="ingested",
             summary=result.summary,
             quality=result.quality,
+            language=result.language,
             ingested_at=datetime.now(),
         )
     )

--- a/src/obsidian_llm_wiki/pipeline/query.py
+++ b/src/obsidian_llm_wiki/pipeline/query.py
@@ -124,6 +124,7 @@ def run_query(
         f"Relevant wiki content:\n{context}\n\n"
         f"Question: {question}\n\n"
         "Answer using the wiki content. Use [[wikilinks]] when referencing wiki concepts. "
+        "Answer in the same language as the user's question. "
         'Return JSON: {"answer": "your full markdown answer here"}'
     )
     result = request_structured(

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -159,10 +159,12 @@ class StateDB:
 
         if row is None:
             # No version record yet. Determine starting state by inspecting schema:
-            # If wiki_articles already has approved_at, this is a fresh DB created
-            # by the current _SCHEMA — all tables/columns exist, just record version.
-            cols = {r[1] for r in self._conn.execute("PRAGMA table_info(wiki_articles)").fetchall()}
-            if "approved_at" in cols:
+            # Check that all columns from the current schema version exist so we
+            # don't skip migrations on a partially-upgraded DB (e.g. v2 DB with
+            # approved_at but no language column).
+            wiki_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(wiki_articles)").fetchall()}
+            note_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(raw_notes)").fetchall()}
+            if "approved_at" in wiki_cols and "language" in note_cols:
                 with self._tx():
                     self._conn.execute(
                         "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, ?)",

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -162,8 +162,12 @@ class StateDB:
             # Check that all columns from the current schema version exist so we
             # don't skip migrations on a partially-upgraded DB (e.g. v2 DB with
             # approved_at but no language column).
-            wiki_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(wiki_articles)").fetchall()}
-            note_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(raw_notes)").fetchall()}
+            wiki_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(wiki_articles)").fetchall()
+            }
+            note_cols = {
+                r[1] for r in self._conn.execute("PRAGMA table_info(raw_notes)").fetchall()
+            }
             if "approved_at" in wiki_cols and "language" in note_cols:
                 with self._tx():
                     self._conn.execute(

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -7,6 +7,7 @@ Handles: dedup via content hash, partial failure recovery, resume.
 Schema versioning: schema_version table tracks migration level.
   v1 — initial (summary/quality columns on raw_notes)
   v2 — rejections, stubs, blocked_concepts tables; approved_at/approval_notes on wiki_articles
+  v3 — language column on raw_notes
 """
 
 from __future__ import annotations
@@ -19,7 +20,7 @@ from pathlib import Path
 
 from .models import RawNoteRecord, WikiArticleRecord
 
-_CURRENT_SCHEMA_VERSION = 2
+_CURRENT_SCHEMA_VERSION = 3
 
 # Full current schema — idempotent (CREATE IF NOT EXISTS).
 # Fresh DBs get all tables + columns from here. Existing DBs use _VERSIONED_MIGRATIONS.
@@ -35,6 +36,7 @@ CREATE TABLE IF NOT EXISTS raw_notes (
     status      TEXT NOT NULL DEFAULT 'new',
     summary     TEXT,
     quality     TEXT,
+    language    TEXT,
     ingested_at TEXT,
     compiled_at TEXT,
     error       TEXT
@@ -111,6 +113,9 @@ _VERSIONED_MIGRATIONS: dict[int, list[str]] = {
            )""",
         "ALTER TABLE wiki_articles ADD COLUMN approved_at TEXT",
         "ALTER TABLE wiki_articles ADD COLUMN approval_notes TEXT",
+    ],
+    3: [
+        "ALTER TABLE raw_notes ADD COLUMN language TEXT",
     ],
 }
 
@@ -210,16 +215,17 @@ class StateDB:
         with self._tx():
             self._conn.execute(
                 """INSERT INTO raw_notes
-                       (path, content_hash, status, summary, quality,
+                       (path, content_hash, status, summary, quality, language,
                         ingested_at, compiled_at, error)
                    VALUES
-                       (:path, :content_hash, :status, :summary, :quality,
+                       (:path, :content_hash, :status, :summary, :quality, :language,
                         :ingested_at, :compiled_at, :error)
                    ON CONFLICT(path) DO UPDATE SET
                        content_hash=excluded.content_hash,
                        status=excluded.status,
                        summary=excluded.summary,
                        quality=excluded.quality,
+                       language=excluded.language,
                        ingested_at=excluded.ingested_at,
                        compiled_at=excluded.compiled_at,
                        error=excluded.error""",
@@ -229,6 +235,7 @@ class StateDB:
                     "status": record.status,
                     "summary": record.summary,
                     "quality": record.quality,
+                    "language": record.language,
                     "ingested_at": record.ingested_at.isoformat() if record.ingested_at else None,
                     "compiled_at": record.compiled_at.isoformat() if record.compiled_at else None,
                     "error": record.error,
@@ -253,6 +260,12 @@ class StateDB:
         else:
             rows = self._conn.execute("SELECT * FROM raw_notes").fetchall()
         return [_row_to_raw(r) for r in rows]
+
+    def get_note_language(self, path: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT language FROM raw_notes WHERE path = ?", (path,)
+        ).fetchone()
+        return row[0] if row else None
 
     def mark_raw_status(self, path: str, status: str, error: str | None = None) -> None:
         now = datetime.now().isoformat()
@@ -530,6 +543,7 @@ def _row_to_raw(row: sqlite3.Row) -> RawNoteRecord:
         status=row["status"],
         summary=row["summary"] if "summary" in keys else None,
         quality=row["quality"] if "quality" in keys else None,
+        language=row["language"] if "language" in keys else None,
         ingested_at=datetime.fromisoformat(row["ingested_at"]) if row["ingested_at"] else None,
         compiled_at=datetime.fromisoformat(row["compiled_at"]) if row["compiled_at"] else None,
         error=row["error"],

--- a/tests/test_cli_reject.py
+++ b/tests/test_cli_reject.py
@@ -1,0 +1,144 @@
+"""Tests for the `olw reject` CLI command — single file and --all flag."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from obsidian_llm_wiki.cli import cli
+from obsidian_llm_wiki.config import Config
+from obsidian_llm_wiki.models import RawNoteRecord, WikiArticleRecord
+from obsidian_llm_wiki.state import StateDB
+
+
+@pytest.fixture
+def vault(tmp_path):
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki").mkdir()
+    (tmp_path / "wiki" / ".drafts").mkdir()
+    (tmp_path / ".olw").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def config(vault):
+    return Config(vault=vault)
+
+
+@pytest.fixture
+def db(config):
+    return StateDB(config.state_db_path)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_draft(vault: Path, title: str, content: str = "# Draft\n\nBody.") -> Path:
+    """Write a minimal draft markdown file."""
+    draft = vault / "wiki" / ".drafts" / f"{title}.md"
+    draft.write_text(f"---\ntitle: {title}\n---\n{content}")
+    return draft
+
+
+def _register_draft(db: StateDB, vault: Path, draft: Path, source: str = "raw/note.md") -> None:
+    """Register a draft article in the state DB."""
+    db.upsert_raw(RawNoteRecord(path=source, content_hash="h1", status="ingested"))
+    db.upsert_article(
+        WikiArticleRecord(
+            path=str(draft.relative_to(vault)),
+            title=draft.stem,
+            sources=[source],
+            content_hash="dh1",
+            is_draft=True,
+        )
+    )
+
+
+def test_reject_single_file(vault, config, db, runner):
+    draft = _make_draft(vault, "My Concept")
+    _register_draft(db, vault, draft)
+
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--feedback", "too vague", str(draft)],
+    )
+
+    assert result.exit_code == 0
+    assert not draft.exists()
+    assert "Draft rejected" in result.output
+
+
+def test_reject_all_rejects_all_drafts(vault, config, db, runner):
+    drafts = [_make_draft(vault, f"Concept {i}") for i in range(3)]
+    for i, d in enumerate(drafts):
+        _register_draft(db, vault, d, source=f"raw/note{i}.md")
+
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--all", "--feedback", "batch reject"],
+        input="\n",  # confirm any prompts
+    )
+
+    assert result.exit_code == 0
+    for d in drafts:
+        assert not d.exists()
+    assert "Rejected 3 draft(s)" in result.output
+
+
+def test_reject_all_empty_drafts_dir(vault, config, db, runner):
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--all", "--feedback", "test"],
+        input="\n",
+    )
+
+    assert result.exit_code == 0
+    assert "No drafts" in result.output
+
+
+def test_reject_all_with_feedback_flag(vault, config, db, runner):
+    draft = _make_draft(vault, "Topic A")
+    _register_draft(db, vault, draft)
+
+    runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--all", "--feedback", "bad quality"],
+        input="\n",
+    )
+
+    rejections = db.get_rejections("Topic A", limit=5)
+    assert len(rejections) == 1
+    assert rejections[0]["feedback"] == "bad quality"
+
+
+def test_reject_no_args_shows_error(vault, config, db, runner):
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault)],
+        input="\n",
+    )
+
+    assert result.exit_code != 0
+
+
+def test_reject_all_and_files_all_wins(vault, config, db, runner):
+    draft_a = _make_draft(vault, "Concept A")
+    draft_b = _make_draft(vault, "Concept B")
+    _register_draft(db, vault, draft_a, source="raw/a.md")
+    _register_draft(db, vault, draft_b, source="raw/b.md")
+
+    # Pass --all AND an extra file — --all should process all drafts
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--all", "--feedback", "x", str(draft_a)],
+        input="\n",
+    )
+
+    assert result.exit_code == 0
+    # Both drafts rejected because --all wins
+    assert not draft_a.exists()
+    assert not draft_b.exists()

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -9,6 +9,7 @@ import pytest
 from obsidian_llm_wiki.config import Config
 from obsidian_llm_wiki.models import RawNoteRecord
 from obsidian_llm_wiki.pipeline.compile import (
+    _resolve_language,
     _write_concept_prompt,
     _write_prompt_legacy,
     approve_drafts,
@@ -332,3 +333,58 @@ def test_compile_concepts_marks_sources_compiled(vault, config, db, fixtures_dir
 
     record = db.get_raw("raw/note.md")
     assert record.status == "compiled"
+
+
+# ── Language tests ─────────────────────────────────────────────────────────────
+
+
+def test_write_concept_prompt_no_language():
+    prompt = _write_concept_prompt("Topic", "source", [])
+    assert "same language as the source notes" in prompt
+
+
+def test_write_concept_prompt_with_language():
+    prompt = _write_concept_prompt("Topic", "source", [], language="fr")
+    assert "Output language: fr" in prompt
+    assert "same language as the source notes" not in prompt
+
+
+def test_write_prompt_legacy_no_language():
+    from obsidian_llm_wiki.models import ArticlePlan
+
+    plan = ArticlePlan(title="T", action="create", path="t.md", reasoning="r", source_paths=[])
+    prompt = _write_prompt_legacy(plan, "source", [])
+    assert "same language as the source notes" in prompt
+
+
+def test_write_prompt_legacy_with_language():
+    from obsidian_llm_wiki.models import ArticlePlan
+
+    plan = ArticlePlan(title="T", action="create", path="t.md", reasoning="r", source_paths=[])
+    prompt = _write_prompt_legacy(plan, "source", [], language="de")
+    assert "Output language: de" in prompt
+
+
+def test_resolve_language_uses_config_over_detected(config, db):
+    r = RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested", language="fr")
+    db.upsert_raw(r)
+    config.pipeline.language = "en"
+    assert _resolve_language(["raw/a.md"], db, config) == "en"
+
+
+def test_resolve_language_uses_detected_when_unambiguous(config, db):
+    for path, lang in [("raw/a.md", "fr"), ("raw/b.md", "fr")]:
+        db.upsert_raw(RawNoteRecord(path=path, content_hash=path, status="ingested", language=lang))
+    assert _resolve_language(["raw/a.md", "raw/b.md"], db, config) == "fr"
+
+
+def test_resolve_language_none_when_mixed(config, db):
+    for path, lang in [("raw/a.md", "fr"), ("raw/b.md", "de")]:
+        db.upsert_raw(RawNoteRecord(path=path, content_hash=path, status="ingested", language=lang))
+    assert _resolve_language(["raw/a.md", "raw/b.md"], db, config) is None
+
+
+def test_resolve_language_none_when_no_detected(config, db):
+    r = RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested", language=None)
+    db.upsert_raw(r)
+    assert _resolve_language(["raw/a.md"], db, config) is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for config.py — PipelineConfig and default_wiki_toml."""
+
+from __future__ import annotations
+
+import tomllib
+
+from obsidian_llm_wiki.config import PipelineConfig, default_wiki_toml
+
+
+def test_pipeline_config_language_default_none():
+    cfg = PipelineConfig()
+    assert cfg.language is None
+
+
+def test_pipeline_config_language_from_dict():
+    cfg = PipelineConfig(**{"language": "fr"})
+    assert cfg.language == "fr"
+
+
+def test_pipeline_config_language_from_toml(tmp_path):
+    toml_content = default_wiki_toml()
+    # default_wiki_toml has language commented out — parse should give None
+    data = tomllib.loads(toml_content)
+    pipeline_data = data.get("pipeline", {})
+    cfg = PipelineConfig(**pipeline_data)
+    assert cfg.language is None
+
+
+def test_default_wiki_toml_contains_language_comment():
+    toml = default_wiki_toml()
+    assert "language" in toml
+    assert "ISO 639-1" in toml
+
+
+def test_pipeline_config_accepts_explicit_language():
+    cfg = PipelineConfig(language="de")
+    assert cfg.language == "de"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -11,6 +11,7 @@ import pytest
 from obsidian_llm_wiki.config import Config
 from obsidian_llm_wiki.models import AnalysisResult
 from obsidian_llm_wiki.pipeline.ingest import (
+    _SYSTEM,
     _analyze_body,
     _build_analysis_prompt,
     _merge_chunk_results,
@@ -457,3 +458,48 @@ def test_analyze_body_parallel_mode(vault):
     result = _analyze_body(body, [], "long.md", client, config2)
     assert client.generate.call_count == -(-200 // 50)  # same chunk count
     assert isinstance(result, AnalysisResult)
+
+
+# ── Language tests ─────────────────────────────────────────────────────────────
+
+
+def test_system_prompt_contains_language_detection_instruction():
+    assert "ISO 639-1" in _SYSTEM
+    assert "language" in _SYSTEM
+
+
+def test_analysis_result_stores_language_in_db(vault, config, db):
+    path = _write_raw(vault, "french_note.md", "# Bonjour\n\nCeci est une note en français.")
+    analysis = json.dumps({
+        "summary": "A French note.",
+        "key_concepts": ["Bonjour"],
+        "suggested_topics": ["Salutations"],
+        "quality": "high",
+        "language": "fr",
+    })
+    client = _make_client(analysis)
+    ingest_note(path, config, client, db)
+    assert db.get_note_language("raw/french_note.md") == "fr"
+
+
+def test_analysis_result_language_none_stored(vault, config, db):
+    path = _write_raw(vault, "unknown.md", "# Mixed content\n\nSome text.")
+    analysis = json.dumps({
+        "summary": "Unknown language note.",
+        "key_concepts": ["Mixed"],
+        "suggested_topics": [],
+        "quality": "medium",
+        "language": None,
+    })
+    client = _make_client(analysis)
+    ingest_note(path, config, client, db)
+    assert db.get_note_language("raw/unknown.md") is None
+
+
+def test_merge_chunk_results_picks_first_detected_language():
+    make = lambda lang: AnalysisResult(  # noqa: E731
+        summary="s", key_concepts=[], suggested_topics=[], quality="high", language=lang
+    )
+    merged = _merge_chunk_results([make(None), make("de"), make("fr")])
+    assert merged.language == "de"
+

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -470,13 +470,15 @@ def test_system_prompt_contains_language_detection_instruction():
 
 def test_analysis_result_stores_language_in_db(vault, config, db):
     path = _write_raw(vault, "french_note.md", "# Bonjour\n\nCeci est une note en français.")
-    analysis = json.dumps({
-        "summary": "A French note.",
-        "key_concepts": ["Bonjour"],
-        "suggested_topics": ["Salutations"],
-        "quality": "high",
-        "language": "fr",
-    })
+    analysis = json.dumps(
+        {
+            "summary": "A French note.",
+            "key_concepts": ["Bonjour"],
+            "suggested_topics": ["Salutations"],
+            "quality": "high",
+            "language": "fr",
+        }
+    )
     client = _make_client(analysis)
     ingest_note(path, config, client, db)
     assert db.get_note_language("raw/french_note.md") == "fr"
@@ -484,13 +486,15 @@ def test_analysis_result_stores_language_in_db(vault, config, db):
 
 def test_analysis_result_language_none_stored(vault, config, db):
     path = _write_raw(vault, "unknown.md", "# Mixed content\n\nSome text.")
-    analysis = json.dumps({
-        "summary": "Unknown language note.",
-        "key_concepts": ["Mixed"],
-        "suggested_topics": [],
-        "quality": "medium",
-        "language": None,
-    })
+    analysis = json.dumps(
+        {
+            "summary": "Unknown language note.",
+            "key_concepts": ["Mixed"],
+            "suggested_topics": [],
+            "quality": "medium",
+            "language": None,
+        }
+    )
     client = _make_client(analysis)
     ingest_note(path, config, client, db)
     assert db.get_note_language("raw/unknown.md") is None
@@ -502,4 +506,3 @@ def test_merge_chunk_results_picks_first_detected_language():
     )
     merged = _merge_chunk_results([make(None), make("de"), make("fr")])
     assert merged.language == "de"
-

--- a/tests/test_pipeline_language.py
+++ b/tests/test_pipeline_language.py
@@ -1,0 +1,101 @@
+"""Integration tests for language detection and config override across the pipeline."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from obsidian_llm_wiki.config import Config
+from obsidian_llm_wiki.models import RawNoteRecord
+from obsidian_llm_wiki.pipeline.compile import _resolve_language, _write_concept_prompt
+from obsidian_llm_wiki.pipeline.ingest import ingest_note
+from obsidian_llm_wiki.pipeline.query import run_query
+from obsidian_llm_wiki.state import StateDB
+
+
+@pytest.fixture
+def vault(tmp_path):
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki").mkdir()
+    (tmp_path / "wiki" / ".drafts").mkdir()
+    (tmp_path / "wiki" / "sources").mkdir()
+    (tmp_path / ".olw").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def config(vault):
+    return Config(vault=vault)
+
+
+@pytest.fixture
+def db(config):
+    return StateDB(config.state_db_path)
+
+
+@pytest.mark.integration
+def test_ingest_detects_and_stores_language(vault, config, db):
+    """Mock LLM returns language='fr' → DB stores it on the raw note."""
+    path = vault / "raw" / "french.md"
+    path.write_text("# Bonjour\n\nCeci est une note en français.")
+
+    analysis = json.dumps({
+        "summary": "A French note.",
+        "key_concepts": ["Bonjour"],
+        "suggested_topics": ["Salutations"],
+        "quality": "high",
+        "language": "fr",
+    })
+    client = MagicMock()
+    client.generate.return_value = analysis
+
+    ingest_note(path, config, client, db)
+    assert db.get_note_language("raw/french.md") == "fr"
+
+
+@pytest.mark.integration
+def test_compile_prompt_uses_detected_language(config, db):
+    """Source note has language='fr' in DB and no config → compile prompt contains 'fr'."""
+    r = RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested", language="fr")
+    db.upsert_raw(r)
+
+    lang = _resolve_language(["raw/a.md"], db, config)
+    assert lang == "fr"
+
+    prompt = _write_concept_prompt("Topic", "source material", [], language=lang)
+    assert "Output language: fr" in prompt
+
+
+@pytest.mark.integration
+def test_compile_prompt_config_wins_over_detected(config, db):
+    """config.pipeline.language='de', detected 'fr' → prompt contains 'de'."""
+    r = RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested", language="fr")
+    db.upsert_raw(r)
+    config.pipeline.language = "de"
+
+    lang = _resolve_language(["raw/a.md"], db, config)
+    assert lang == "de"
+
+    prompt = _write_concept_prompt("Topic", "source material", [], language=lang)
+    assert "Output language: de" in prompt
+    assert "fr" not in prompt
+
+
+@pytest.mark.integration
+def test_query_answer_prompt_has_language_instruction(vault, config, db):
+    """Answer prompt tells LLM to respond in user's question language."""
+    index = vault / "wiki" / "index.md"
+    index.write_text("# Index\n\n- [[Topic]]\n")
+    (vault / "wiki" / "Topic.md").write_text("---\ntitle: Topic\n---\nContent.")
+
+    selection_json = json.dumps({"pages": ["Topic"]})
+    answer_json = json.dumps({"answer": "Réponse."})
+    client = MagicMock()
+    client.generate.side_effect = [selection_json, answer_json]
+
+    run_query(config, client, db, "Qu'est-ce que Topic?")
+
+    second_call_prompt = client.generate.call_args_list[1].kwargs.get("prompt", "")
+    assert "same language as the user's question" in second_call_prompt

--- a/tests/test_pipeline_language.py
+++ b/tests/test_pipeline_language.py
@@ -41,13 +41,15 @@ def test_ingest_detects_and_stores_language(vault, config, db):
     path = vault / "raw" / "french.md"
     path.write_text("# Bonjour\n\nCeci est une note en français.")
 
-    analysis = json.dumps({
-        "summary": "A French note.",
-        "key_concepts": ["Bonjour"],
-        "suggested_topics": ["Salutations"],
-        "quality": "high",
-        "language": "fr",
-    })
+    analysis = json.dumps(
+        {
+            "summary": "A French note.",
+            "key_concepts": ["Bonjour"],
+            "suggested_topics": ["Salutations"],
+            "quality": "high",
+            "language": "fr",
+        }
+    )
     client = MagicMock()
     client.generate.return_value = analysis
 

--- a/tests/test_pipeline_reject_all.py
+++ b/tests/test_pipeline_reject_all.py
@@ -100,11 +100,13 @@ def test_reject_all_then_recompile_uses_feedback(vault, config, db, runner):
     assert len(rej_b) == 1 and rej_b[0]["feedback"] == "wrong language"
 
     # Recompile — mock LLM, capture prompts
-    article_json = json.dumps({
-        "title": "Concept A",
-        "content": "Rewritten content.",
-        "tags": ["concept-a"],
-    })
+    article_json = json.dumps(
+        {
+            "title": "Concept A",
+            "content": "Rewritten content.",
+            "tags": ["concept-a"],
+        }
+    )
     client = MagicMock()
     client.generate.return_value = article_json
 

--- a/tests/test_pipeline_reject_all.py
+++ b/tests/test_pipeline_reject_all.py
@@ -1,0 +1,121 @@
+"""Integration tests for reject --all → recompile with feedback loop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from obsidian_llm_wiki.cli import cli
+from obsidian_llm_wiki.config import Config
+from obsidian_llm_wiki.models import RawNoteRecord, WikiArticleRecord
+from obsidian_llm_wiki.pipeline.compile import compile_concepts
+from obsidian_llm_wiki.state import StateDB
+
+
+@pytest.fixture
+def vault(tmp_path):
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki").mkdir()
+    (tmp_path / "wiki" / ".drafts").mkdir()
+    (tmp_path / "wiki" / "sources").mkdir()
+    (tmp_path / ".olw").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def config(vault):
+    return Config(vault=vault)
+
+
+@pytest.fixture
+def db(config):
+    return StateDB(config.state_db_path)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _write_raw(vault: Path, name: str, content: str = "# Note\n\nBody.") -> Path:
+    p = vault / "raw" / name
+    p.write_text(content)
+    return p
+
+
+def _make_draft(vault: Path, title: str) -> Path:
+    draft = vault / "wiki" / ".drafts" / f"{title}.md"
+    draft.write_text(f"---\ntitle: {title}\n---\n# {title}\n\nDraft content.")
+    return draft
+
+
+def _register_draft_and_source(db: StateDB, vault: Path, draft: Path, source: str) -> None:
+    db.upsert_raw(RawNoteRecord(path=source, content_hash="h1", status="compiled"))
+    db.upsert_article(
+        WikiArticleRecord(
+            path=str(draft.relative_to(vault)),
+            title=draft.stem,
+            sources=[source],
+            content_hash="dh",
+            is_draft=True,
+        )
+    )
+
+
+@pytest.mark.integration
+def test_reject_all_then_recompile_uses_feedback(vault, config, db, runner):
+    """
+    Full loop: create 2 drafts → reject --all with feedback →
+    verify drafts deleted + rejections in DB → compile again →
+    verify feedback injected into compile prompt.
+    """
+    # Setup: 2 source notes and their drafts
+    _write_raw(vault, "note_a.md", "# Note A\n\nContent A.")
+    _write_raw(vault, "note_b.md", "# Note B\n\nContent B.")
+    draft_a = _make_draft(vault, "Concept A")
+    draft_b = _make_draft(vault, "Concept B")
+    _register_draft_and_source(db, vault, draft_a, "raw/note_a.md")
+    _register_draft_and_source(db, vault, draft_b, "raw/note_b.md")
+    db.upsert_concepts("raw/note_a.md", ["Concept A"])
+    db.upsert_concepts("raw/note_b.md", ["Concept B"])
+
+    # Reject all
+    result = runner.invoke(
+        cli,
+        ["reject", "--vault", str(vault), "--all", "--feedback", "wrong language"],
+        input="\n",
+    )
+    assert result.exit_code == 0
+    assert not draft_a.exists()
+    assert not draft_b.exists()
+
+    # Rejections stored in DB
+    rej_a = db.get_rejections("Concept A", limit=3)
+    rej_b = db.get_rejections("Concept B", limit=3)
+    assert len(rej_a) == 1 and rej_a[0]["feedback"] == "wrong language"
+    assert len(rej_b) == 1 and rej_b[0]["feedback"] == "wrong language"
+
+    # Recompile — mock LLM, capture prompts
+    article_json = json.dumps({
+        "title": "Concept A",
+        "content": "Rewritten content.",
+        "tags": ["concept-a"],
+    })
+    client = MagicMock()
+    client.generate.return_value = article_json
+
+    # Mark sources as ingested so compile picks them up
+    db.mark_raw_status("raw/note_a.md", "ingested")
+    db.mark_raw_status("raw/note_b.md", "ingested")
+
+    compile_concepts(config=config, client=client, db=db)
+
+    # At least one compile call prompt should contain the feedback
+    all_prompts = [call.kwargs.get("prompt", "") for call in client.generate.call_args_list]
+    assert any("wrong language" in p for p in all_prompts), (
+        "Expected rejection feedback in at least one compile prompt"
+    )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -156,3 +156,19 @@ def test_run_query_passes_index_to_first_call(vault, config, db):
 
     first_call_prompt = client.generate.call_args_list[0].kwargs.get("prompt", "")
     assert "Special Topic" in first_call_prompt
+
+
+def test_query_answer_prompt_has_language_instruction(vault, config, db):
+    """Answer prompt must tell LLM to match user's question language."""
+    index_text = "# Wiki Index\n\n## Concepts\n- [[Topic]]\n"
+    _write_index(config, index_text)
+    _write_concept_page(config, "Topic")
+
+    selection_json = json.dumps({"pages": ["Topic"]})
+    answer_json = json.dumps({"answer": "Answer."})
+    client = _make_client(selection_json, answer_json)
+
+    run_query(config, client, db, "What is Topic?")
+
+    second_call_prompt = client.generate.call_args_list[1].kwargs.get("prompt", "")
+    assert "same language as the user's question" in second_call_prompt

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -181,9 +181,47 @@ def test_load_config_no_vault_exits(monkeypatch: pytest.MonkeyPatch, cfg_dir: Pa
     from obsidian_llm_wiki.cli import _load_config
 
     monkeypatch.delenv("OLW_VAULT", raising=False)
+    monkeypatch.chdir(cfg_dir)
     with pytest.raises(SystemExit) as exc:
         _load_config(None)
     assert exc.value.code == 1
+
+
+def test_load_config_detects_vault_from_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg_dir: Path
+):
+    """_load_config(None) detects vault when CWD contains wiki.toml."""
+    vault = tmp_path / "myvault"
+    vault.mkdir()
+    (vault / "wiki.toml").write_text(
+        '[models]\nfast = "gemma4:e4b"\nheavy = "gemma4:e4b"\n[ollama]\nurl = "http://localhost:11434"\n'
+    )
+    monkeypatch.delenv("OLW_VAULT", raising=False)
+    monkeypatch.chdir(vault)
+
+    from obsidian_llm_wiki.cli import _load_config
+
+    config = _load_config(None)
+    assert config.vault == vault
+
+
+def test_load_config_detects_vault_from_subdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cfg_dir: Path
+):
+    """_load_config(None) walks up from a subdirectory to find wiki.toml."""
+    vault = tmp_path / "myvault"
+    subdir = vault / "raw" / "notes"
+    subdir.mkdir(parents=True)
+    (vault / "wiki.toml").write_text(
+        '[models]\nfast = "gemma4:e4b"\nheavy = "gemma4:e4b"\n[ollama]\nurl = "http://localhost:11434"\n'
+    )
+    monkeypatch.delenv("OLW_VAULT", raising=False)
+    monkeypatch.chdir(subdir)
+
+    from obsidian_llm_wiki.cli import _load_config
+
+    config = _load_config(None)
+    assert config.vault == vault
 
 
 # ── olw setup --non-interactive ───────────────────────────────────────────────

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from obsidian_llm_wiki.models import RawNoteRecord, WikiArticleRecord
-from obsidian_llm_wiki.state import StateDB, _CURRENT_SCHEMA_VERSION
+from obsidian_llm_wiki.state import _CURRENT_SCHEMA_VERSION, StateDB
 
 
 @pytest.fixture

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -360,10 +360,10 @@ def test_approve_article_sets_timestamp(db):
 
 
 def test_schema_version_set_on_fresh_db(db):
-    """Fresh DB should have schema_version = 2."""
+    """Fresh DB should have schema_version = current."""
     row = db._conn.execute("SELECT version FROM schema_version").fetchone()
     assert row is not None
-    assert row[0] == 2
+    assert row[0] == 3
 
 
 def test_schema_version_idempotent(tmp_path):
@@ -373,11 +373,11 @@ def test_schema_version_idempotent(tmp_path):
     db1.close()
     db2 = StateDB(path)
     row = db2._conn.execute("SELECT version FROM schema_version").fetchone()
-    assert row[0] == 2
+    assert row[0] == 3
 
 
 def test_legacy_migration_from_v0(tmp_path):
-    """DB with no schema_version row and no approved_at column → migrates to v2."""
+    """DB with no schema_version row and no approved_at column → migrates to v3."""
     import sqlite3
 
     path = tmp_path / ".olw" / "state.db"
@@ -408,10 +408,10 @@ def test_legacy_migration_from_v0(tmp_path):
     conn.commit()
     conn.close()
 
-    # Opening via StateDB should apply v1 + v2 migrations
+    # Opening via StateDB should apply v1 + v2 + v3 migrations
     db = StateDB(path)
     row = db._conn.execute("SELECT version FROM schema_version").fetchone()
-    assert row[0] == 2
+    assert row[0] == 3
 
     # Verify v0.2 tables exist after migration
     tables = {
@@ -422,7 +422,29 @@ def test_legacy_migration_from_v0(tmp_path):
     assert "stubs" in tables
     assert "blocked_concepts" in tables
 
-    # Verify approved_at column added to wiki_articles
+    # Verify approved_at column added to wiki_articles (v2)
     cols = {r[1] for r in db._conn.execute("PRAGMA table_info(wiki_articles)").fetchall()}
     assert "approved_at" in cols
     assert "approval_notes" in cols
+
+    # Verify language column added to raw_notes (v3)
+    raw_cols = {r[1] for r in db._conn.execute("PRAGMA table_info(raw_notes)").fetchall()}
+    assert "language" in raw_cols
+
+
+def test_upsert_note_stores_language(db):
+    r = RawNoteRecord(path="raw/note.md", content_hash="abc", status="ingested", language="fr")
+    db.upsert_raw(r)
+    got = db.get_raw("raw/note.md")
+    assert got.language == "fr"
+    assert db.get_note_language("raw/note.md") == "fr"
+
+
+def test_upsert_note_language_none(db):
+    r = RawNoteRecord(path="raw/note.md", content_hash="abc", status="ingested", language=None)
+    db.upsert_raw(r)
+    assert db.get_note_language("raw/note.md") is None
+
+
+def test_get_note_language_missing_path(db):
+    assert db.get_note_language("raw/nonexistent.md") is None

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from obsidian_llm_wiki.models import RawNoteRecord, WikiArticleRecord
-from obsidian_llm_wiki.state import StateDB
+from obsidian_llm_wiki.state import StateDB, _CURRENT_SCHEMA_VERSION
 
 
 @pytest.fixture
@@ -363,7 +363,7 @@ def test_schema_version_set_on_fresh_db(db):
     """Fresh DB should have schema_version = current."""
     row = db._conn.execute("SELECT version FROM schema_version").fetchone()
     assert row is not None
-    assert row[0] == 3
+    assert row[0] == _CURRENT_SCHEMA_VERSION
 
 
 def test_schema_version_idempotent(tmp_path):
@@ -373,7 +373,7 @@ def test_schema_version_idempotent(tmp_path):
     db1.close()
     db2 = StateDB(path)
     row = db2._conn.execute("SELECT version FROM schema_version").fetchone()
-    assert row[0] == 3
+    assert row[0] == _CURRENT_SCHEMA_VERSION
 
 
 def test_legacy_migration_from_v0(tmp_path):
@@ -411,7 +411,7 @@ def test_legacy_migration_from_v0(tmp_path):
     # Opening via StateDB should apply v1 + v2 + v3 migrations
     db = StateDB(path)
     row = db._conn.execute("SELECT version FROM schema_version").fetchone()
-    assert row[0] == 3
+    assert row[0] == _CURRENT_SCHEMA_VERSION
 
     # Verify v0.2 tables exist after migration
     tables = {


### PR DESCRIPTION
## Summary

- Multi-language support: notes ingested in their detected language, articles compiled in the same language
- `olw review --reject-all`: batch-reject all pending drafts with shared feedback
- Vault auto-detection: `olw` now finds your vault by walking up from CWD — no more `--vault` required when inside a vault
- Fix: `olw review` menu shortcuts were invisible in terminals with limited Rich styling support

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for full details.

## Test plan

- [x] `uv run pytest` — 413 passed, 1 skipped
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Smoke test with LM Studio + gemma-4-e4b — 63/63 checks passed

## After merge

```bash
bash scripts/release.sh 0.4.0 --tag
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)