### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.5.0] - 2026-04-18
+
+### Highlights
+
+**v0.5 makes the wiki resilient to the natural way humans refer to concepts.** When you write about "Program Counter" once and later mention "PC", `olw` now recognizes they're the same thing. Aliases are extracted at ingest, stored alongside articles, and used everywhere the pipeline resolves a concept name — so broken links to common abbreviations get repaired automatically, and queries using either form land on the right article.
+
+### New Features
+
+- **Concept aliases** — during ingest, the fast model extracts short aliases for each concept (e.g. "Program Counter (PC)" → alias `PC`). Aliases are stored in the state DB and written into each article's `aliases:` frontmatter, so Obsidian picks them up for its own link suggestions.
+
+- **Alias-aware link repair** — `olw maintain --fix` now rewrites broken `[[Alias]]` wikilinks to `[[Canonical|Alias]]` when an unambiguous alias is known. Links inside code fences are left untouched. Still-unresolvable targets fall through to stub creation as before.
+
+- **Alias-aware queries and health checks** — `olw query` resolves page routes through the alias map when the canonical name misses, and `olw lint` counts alias forms as valid links so they don't get flagged as broken.
+
+- **`olw status --failed`** — filter the status report to only failed notes with their error messages. Useful when triaging after a bulk ingest.
+
+### Changes
+
+- The auto-generated wiki index is now `wiki/index.md` (lowercase). Vaults created before v0.5 with `wiki/INDEX.md` are handled transparently — no manual rename needed.
+- Smoke test suite expanded: 105 end-to-end assertions now cover lint issue-type coverage, `maintain --fix` idempotency, stub frontmatter shape, legacy-compile bit-rot, and the `status --failed` filter.
+
+### Breaking Changes
+
+None. Existing vaults upgrade automatically on first `olw` run: the DB gains a `concept_aliases` table, aliases are backfilled from current concept titles (deterministic, no LLM calls), and any legacy `INDEX.md` is treated like the new lowercase form.
+
 ## [0.4.0] - 2026-04-16
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -40,16 +40,17 @@ The wiki lives in Obsidian, so you get the graph view, backlinks, and Dataview q
 - **Rich review interface** — `olw review` lists drafts ranked by rejection count, shows diffs vs published and vs the last rejected version
 - **Pipeline orchestrator** — `olw run` runs ingest → compile → lint → [approve] as one command with timing and failure classification
 - **Selective recompile** — after a file save, only concepts linked to that source are recompiled (not the entire wiki)
-- **Self-maintenance** — `olw maintain` creates stub articles for broken wikilinks, suggests orphan link fixes, and warns about low-quality source distribution
+- **Self-maintenance** — `olw maintain --fix` repairs broken wikilinks via the alias map, creates stub articles for genuinely missing targets, and normalizes `[[Alias]]` links across published pages to `[[Canonical|Alias]]`
 - **Manual edit protection** — edited an article by hand? The compiler detects the change and skips it
 - **Source traceability** — every article links back to the raw notes it was built from
 - **File watcher** — `olw watch` auto-processes anything dropped into `raw/`
 - **Wiki health checks** — `olw lint` detects orphans, broken links, stale articles (no LLM needed)
 - **Query your wiki** — `olw query "what is X?"` answers from your published articles
 - **Git safety net** — every auto-action is committed; `olw undo` reverts safely
+- **Concept aliases** — aliases (e.g. `PC` for "Program Counter") are extracted at ingest, written to each article's frontmatter, and used to resolve queries and repair broken wikilinks (`olw maintain --fix` rewrites `[[PC]]` to `[[Program Counter|PC]]`)
 - **Multi-language** — automatically detects the language of each note at ingest time; articles are written in the detected language; override globally with `language = "en"` in `wiki.toml`
 - **Multi-provider** — swap Ollama for Groq, Together AI, LM Studio, vLLM, Azure OpenAI, or any OpenAI-compatible endpoint via `olw setup`
-- **Offline test suite** — all 373 tests run without Ollama or any provider
+- **Offline test suite** — all 418 tests run without Ollama or any provider
 
 ---
 
@@ -398,7 +399,7 @@ After editing `wiki.toml`, no reinstall is needed. Run `olw compile --force` to 
 | `olw reject --all --feedback "..."` | Discard all drafts with feedback |
 | `olw unblock "Concept"` | Re-enable a concept blocked after 5 rejections |
 | `olw maintain` | Health check + stubs + orphan and merge suggestions |
-| `olw maintain --fix` | Auto-fix issues and create stub articles |
+| `olw maintain --fix` | Repair broken alias links, create stubs, normalize alias wikilinks |
 | `olw maintain --dry-run` | Report issues without making changes |
 | `olw status` | Show pipeline state and pending drafts |
 | `olw status --failed` | List failed notes with error messages |
@@ -479,10 +480,14 @@ uv sync --group dev
 uv run pytest
 ```
 
-For the full end-to-end smoke test (requires a running Ollama instance):
+For the full end-to-end smoke test (requires a running provider):
 
 ```bash
-OLLAMA_URL=http://localhost:11434 bash scripts/smoke_test.sh
+# Ollama (default)
+bash scripts/smoke_test.sh
+
+# LM Studio or any other OpenAI-compatible endpoint
+PROVIDER=lm_studio bash scripts/smoke_test.sh
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-llm-wiki"
-version = "0.4.0"
+version = "0.5.0"
 description = "Convert Obsidian notes into an AI-maintained wiki using local or cloud LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -150,6 +150,11 @@ check "wiki/sources/ created"  "test -d $VAULT_DIR/wiki/sources"
 check ".olw/ created"          "test -d $VAULT_DIR/.olw"
 check "wiki.toml created"      "test -f $VAULT_DIR/wiki.toml"
 check "git repo initialised"   "test -d $VAULT_DIR/.git"
+# #27: init must write wiki/index.md with lowercase name.
+# Can't use `test -f INDEX.md` on macOS APFS (case-insensitive) — it matches index.md.
+# Instead, check the actual on-disk filename via ls (ls preserves stored casing).
+_ACTUAL_INDEX=$(ls "$VAULT_DIR/wiki/" | { grep -i '^index\.md$' || true; } | head -1)
+check "wiki index file is lowercase index.md (issue #27)" "test '$_ACTUAL_INDEX' = 'index.md'"
 
 # Write provider-appropriate wiki.toml
 if [[ "$PROVIDER" == "ollama" ]]; then
@@ -340,6 +345,22 @@ if [[ "$SOURCE_COUNT" -gt 0 ]]; then
     check "source pages have concept wikilinks" "test '$CONCEPT_LINKS' -ge 1"
 fi
 
+# #28: concept_aliases table should be populated after ingest
+ALIAS_COUNT=$(python3 - <<PYEOF
+import sqlite3
+conn = sqlite3.connect("$VAULT_DIR/.olw/state.db")
+try:
+    n = conn.execute("SELECT COUNT(*) FROM concept_aliases").fetchone()[0]
+    print(n)
+except Exception:
+    print(0)
+conn.close()
+PYEOF
+)
+check "concept_aliases table populated after ingest (issue #28)" \
+    "test '$ALIAS_COUNT' -gt 0"
+info "Aliases stored in DB: $ALIAS_COUNT"
+
 # ── Language detection check ──────────────────────────────────────────────────
 header "Language detection (ingest)"
 
@@ -466,6 +487,100 @@ rm -f "$_YAML_VALIDATOR"
 check "all published pages have valid YAML" "test $YAML_FAIL -eq 0"
 check "no published pages have invalid tags (spaces/uppercase/special)" "test $TAG_FAIL -eq 0"
 
+# Empty wikilinks [[]] in published articles indicate a model output bug
+EMPTY_WIKILINK_FILES=$({ grep -rl '\[\[\]\]' "$VAULT_DIR/wiki/" \
+    --include='*.md' --exclude-dir='.drafts' --exclude-dir='sources' \
+    --exclude-dir='queries' 2>/dev/null || true; } | wc -l | tr -d ' ')
+check "no published article contains empty [[]] wikilinks" \
+    "test '$EMPTY_WIKILINK_FILES' -eq 0"
+
+# #28: at least one published article must carry an aliases: field in frontmatter.
+# Aliases table populated is already asserted above; this asserts compile actually
+# propagated them into article frontmatter (the user-visible contract).
+ARTICLES_WITH_ALIASES=$({ grep -rl '^aliases:' "$VAULT_DIR/wiki/" \
+    --include='*.md' --exclude-dir='.drafts' --exclude-dir='sources' \
+    --exclude-dir='queries' 2>/dev/null || true; } | wc -l | tr -d ' ')
+info "Articles with aliases frontmatter: $ARTICLES_WITH_ALIASES"
+check "at least one published article has aliases: frontmatter (issue #28)" \
+    "test '$ARTICLES_WITH_ALIASES' -ge 1"
+
+# ── Lint issue-type coverage (corrupt → assert → restore) ────────────────────
+# Exercises lint code paths that would otherwise only fire in the wild:
+# inline_tag, missing_frontmatter, invalid_tag, stale, low_confidence.
+# Vault is clean at this point (post-approve, pre-undo).
+header "Lint issue-type coverage"
+
+_VICTIM=$(find "$VAULT_DIR/wiki" -maxdepth 1 -name '*.md' \
+    ! -name 'index.md' ! -name 'log.md' 2>/dev/null | head -1)
+
+if [[ -n "$_VICTIM" ]]; then
+    _VICTIM_BACKUP=$(mktemp)
+    cp "$_VICTIM" "$_VICTIM_BACKUP"
+
+    # inline_tag — regex-scanned in body
+    echo "" >> "$_VICTIM"
+    echo "#smoke-inline-tag" >> "$_VICTIM"
+    _LT_RC=0; LT_OUT=$($OLW lint 2>&1) || _LT_RC=$?
+    check "lint exits 0 after inline_tag corruption" "test $_LT_RC -eq 0"
+    check "lint detects inline_tag" "echo \"\$LT_OUT\" | grep -qE 'inline_tag'"
+    cp "$_VICTIM_BACKUP" "$_VICTIM"
+
+    # missing_frontmatter — rewrite victim with only body, no frontmatter
+    python3 - "$_VICTIM" <<'PYEOF'
+import sys
+path = sys.argv[1]
+with open(path, 'w') as f:
+    f.write("Plain body, no frontmatter.\n")
+PYEOF
+    _LT_RC=0; LT_OUT=$($OLW lint 2>&1) || _LT_RC=$?
+    check "lint exits 0 after missing_frontmatter corruption" "test $_LT_RC -eq 0"
+    check "lint detects missing_frontmatter" \
+        "echo \"\$LT_OUT\" | grep -qE 'missing_frontmatter'"
+    cp "$_VICTIM_BACKUP" "$_VICTIM"
+
+    # invalid_tag — inject uppercase/spaced tag into frontmatter.
+    # Use uv run python because system python3 has no 'frontmatter' module.
+    uv run --project "$REPO_DIR" python - "$_VICTIM" <<'PYEOF'
+import sys, frontmatter
+path = sys.argv[1]
+m = frontmatter.load(path)
+m['tags'] = ['Bad Tag', 'UPPER']
+with open(path, 'w') as f:
+    f.write(frontmatter.dumps(m))
+PYEOF
+    _LT_RC=0; LT_OUT=$($OLW lint 2>&1) || _LT_RC=$?
+    check "lint exits 0 after invalid_tag corruption" "test $_LT_RC -eq 0"
+    check "lint detects invalid_tag" "echo \"\$LT_OUT\" | grep -qE 'invalid_tag'"
+    cp "$_VICTIM_BACKUP" "$_VICTIM"
+
+    # low_confidence — set confidence below threshold (0.3, strict <)
+    uv run --project "$REPO_DIR" python - "$_VICTIM" <<'PYEOF'
+import sys, frontmatter
+path = sys.argv[1]
+m = frontmatter.load(path)
+m['confidence'] = 0.1
+with open(path, 'w') as f:
+    f.write(frontmatter.dumps(m))
+PYEOF
+    _LT_RC=0; LT_OUT=$($OLW lint 2>&1) || _LT_RC=$?
+    check "lint exits 0 after low_confidence corruption" "test $_LT_RC -eq 0"
+    check "lint detects low_confidence" \
+        "echo \"\$LT_OUT\" | grep -qE 'low_confidence'"
+    cp "$_VICTIM_BACKUP" "$_VICTIM"
+
+    # stale — append text without recompile so body hash diverges from DB record
+    echo "" >> "$_VICTIM"
+    echo "Untracked manual edit to trigger stale detection." >> "$_VICTIM"
+    _LT_RC=0; LT_OUT=$($OLW lint 2>&1) || _LT_RC=$?
+    check "lint exits 0 after stale corruption" "test $_LT_RC -eq 0"
+    check "lint detects stale" "echo \"\$LT_OUT\" | grep -qE 'stale'"
+    cp "$_VICTIM_BACKUP" "$_VICTIM"
+
+    rm -f "$_VICTIM_BACKUP"
+else
+    info "Lint coverage block skipped (no published article available)"
+fi
+
 # ── Git log ───────────────────────────────────────────────────────────────────
 header "Git history"
 git -C "$VAULT_DIR" log --oneline
@@ -517,8 +632,10 @@ if [[ -n "$WIKI_ARTICLE" ]]; then
 
     # Re-ingest to create a new 'ingested' note that would normally trigger compile
     # Use the already ingested note (force it back to ingested)
-    COMPILE_OUT=$($OLW compile 2>&1 || true)
+    _MEC_RC=0
+    COMPILE_OUT=$($OLW compile 2>&1) || _MEC_RC=$?
     echo "$COMPILE_OUT"
+    check "compile after manual edit exits 0" "test $_MEC_RC -eq 0"
     # Manually edited article should be skipped (not recompiled)
     DRAFT_AFTER_EDIT=$(find "$VAULT_DIR/wiki/.drafts" -name "$(basename $WIKI_ARTICLE)" 2>/dev/null | wc -l | tr -d ' ')
     check "manually edited article skipped in compile" \
@@ -529,7 +646,9 @@ fi
 header "Duplicate detection"
 cp "$VAULT_DIR/raw/quantum-computing.md" "$VAULT_DIR/raw/quantum-computing-copy.md" 2>/dev/null || true
 
-INGEST_OUT=$($OLW ingest "$VAULT_DIR/raw/quantum-computing-copy.md" 2>&1 || true)
+_DUP_RC=0
+INGEST_OUT=$($OLW ingest "$VAULT_DIR/raw/quantum-computing-copy.md" 2>&1) || _DUP_RC=$?
+check "duplicate ingest exits 0" "test $_DUP_RC -eq 0"
 _TMP=$(mktemp); echo "$INGEST_OUT" > "$_TMP"
 check "duplicate skipped" "grep -qiE 'skip|duplicate|already' \"$_TMP\""
 rm -f "$_TMP"
@@ -541,31 +660,37 @@ info "Approving drafts so query has articles to search..."
 $OLW approve --all 2>&1 || true
 
 info "Running query against wiki..."
-QUERY_OUT=$($OLW query "What is a qubit?" 2>&1 || true)
+_Q_RC=0
+QUERY_OUT=$($OLW query "What is a qubit?" 2>&1) || _Q_RC=$?
 echo "$QUERY_OUT"
+check "query exits 0" "test $_Q_RC -eq 0"
 _TMP=$(mktemp); echo "$QUERY_OUT" > "$_TMP"
 check "query returns an answer" \
     "grep -qiE 'qubit|quantum|superposition|bit' \"$_TMP\""
 rm -f "$_TMP"
 
 info "Running query with --save..."
-QUERY_SAVE_OUT=$($OLW query --save "What algorithms are used in quantum computing?" 2>&1 || true)
+_QS_RC=0
+QUERY_SAVE_OUT=$($OLW query --save "What algorithms are used in quantum computing?" 2>&1) || _QS_RC=$?
 echo "$QUERY_SAVE_OUT"
+check "query --save exits 0" "test $_QS_RC -eq 0"
 QUERY_COUNT=$(find "$VAULT_DIR/wiki/queries" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
 check "query --save creates file in wiki/queries/" "test \"$QUERY_COUNT\" -ge 1"
 
 # ── Lint (Stage 3) ────────────────────────────────────────────────────────────
 header "olw lint (Stage 3)"
-LINT_OUT=$($OLW lint 2>&1 || true)
+LINT_OUT=$($OLW lint 2>&1); _LINT_RC=$?
 echo "$LINT_OUT"
+check "lint exits 0" "test $_LINT_RC -eq 0"
 _TMP=$(mktemp); echo "$LINT_OUT" > "$_TMP"
-check "lint reports health score" \
-    "grep -qiE 'health|score|100|issue' \"$_TMP\""
+# CLI prints: "Health: {score}/100  {summary}"
+check "lint prints Health: <score>/100 header" \
+    "grep -qE 'Health: [0-9]+(\.[0-9]+)?/100' \"$_TMP\""
 rm -f "$_TMP"
 
-# Lint --fix (should not crash even if no fixable issues)
-$OLW lint --fix 2>&1 || true
-pass "lint --fix runs without error"
+# Lint --fix must exit 0 — crashes here used to be masked by || true + unconditional pass
+$OLW lint --fix > /dev/null 2>&1; _LINTFIX_RC=$?
+check "lint --fix exits 0" "test $_LINTFIX_RC -eq 0"
 
 # ── Retry failed (Stage 4) ────────────────────────────────────────────────────
 header "olw compile --retry-failed (Stage 4)"
@@ -582,8 +707,19 @@ conn.execute("""
 conn.commit()
 conn.close()
 PYEOF
+
+# status --failed should narrow to just the failed record
+_SF_RC=0
+STATUS_FAILED=$($OLW status --failed 2>&1) || _SF_RC=$?
+check "status --failed exits 0" "test $_SF_RC -eq 0"
+check "status --failed lists the failed note" \
+    "echo \"\$STATUS_FAILED\" | grep -qF 'raw/fake-failed.md'"
+
 _RETRY_TMP=$(mktemp)
-$OLW compile --retry-failed 2>&1 | tee "$_RETRY_TMP" || true
+_RETRY_RC=0
+$OLW compile --retry-failed > "$_RETRY_TMP" 2>&1 || _RETRY_RC=$?
+cat "$_RETRY_TMP"
+check "compile --retry-failed exits 0" "test $_RETRY_RC -eq 0"
 check "retry-failed reports failed notes" \
     "grep -qiE 'retry|failed|not found|re-ingest' \"$_RETRY_TMP\""
 rm -f "$_RETRY_TMP"
@@ -608,8 +744,10 @@ Model-free methods learn directly from experience. Model-based methods build
 an internal model of the environment for planning.
 EOF
 
-RUN_OUT=$($OLW run 2>&1 || true)
+_RUN_RC=0
+RUN_OUT=$($OLW run 2>&1) || _RUN_RC=$?
 echo "$RUN_OUT"
+check "olw run exits 0" "test $_RUN_RC -eq 0"
 _TMP=$(mktemp); echo "$RUN_OUT" > "$_TMP"
 check "olw run completes without fatal error" \
     "! grep -qiE 'traceback|exception|fatal' \"$_TMP\""
@@ -618,7 +756,9 @@ check "olw run reports ingested or compiled" \
 rm -f "$_TMP"
 
 DRAFTS_BEFORE=$(find "$VAULT_DIR/wiki/.drafts" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-RUN_DRYRUN_OUT=$($OLW run --dry-run 2>&1 || true)
+_RUNDRY_RC=0
+RUN_DRYRUN_OUT=$($OLW run --dry-run 2>&1) || _RUNDRY_RC=$?
+check "olw run --dry-run exits 0" "test $_RUNDRY_RC -eq 0"
 DRAFTS_AFTER=$(find "$VAULT_DIR/wiki/.drafts" -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
 _TMP=$(mktemp); echo "$RUN_DRYRUN_OUT" > "$_TMP"
 check "olw run --dry-run makes no LLM calls (no new drafts)" \
@@ -643,10 +783,11 @@ conn.close()
 PYEOF
 
 $OLW compile 2>&1 || true
+# Model may or may not annotate (confidence-dependent). The load-bearing assertion is that
+# approve strips any annotations that did land — covered below.
 DRAFTS_WITH_ANNOTATION=$({ grep -rl 'olw-auto' "$VAULT_DIR/wiki/.drafts/" 2>/dev/null || true; } \
     | wc -l | tr -d ' ')
-# Not guaranteed to annotate since model may produce high confidence — just check no crash
-pass "annotation check ran (found $DRAFTS_WITH_ANNOTATION annotated draft(s))"
+info "Annotated drafts before approve: $DRAFTS_WITH_ANNOTATION"
 
 # Verify annotations are stripped on approve
 $OLW approve --all 2>&1 || true
@@ -677,8 +818,10 @@ if [[ -n "$REJECT_DRAFT" ]]; then
     DRAFT_TITLE=$(grep '^title:' "$REJECT_DRAFT" | head -1 | sed 's/title: *//')
     info "Rejecting draft: $DRAFT_TITLE"
 
-    REJECT_OUT=$($OLW reject "$REJECT_DRAFT" --feedback "Too brief, needs more concrete examples" 2>&1 || true)
+    _REJ_RC=0
+    REJECT_OUT=$($OLW reject "$REJECT_DRAFT" --feedback "Too brief, needs more concrete examples" 2>&1) || _REJ_RC=$?
     echo "$REJECT_OUT"
+    check "reject exits 0" "test $_REJ_RC -eq 0"
     check "reject removes draft file" "test ! -f \"$REJECT_DRAFT\""
     check "reject confirms feedback saved" \
         "echo \"$REJECT_OUT\" | grep -qiE 'feedback|saved|rejection|next compile'"
@@ -692,8 +835,10 @@ conn.execute("UPDATE raw_notes SET status='ingested' WHERE path='raw/quantum-com
 conn.commit()
 conn.close()
 PYEOF
-    COMPILE_OUT2=$($OLW compile 2>&1 || true)
+    _CAR_RC=0
+    COMPILE_OUT2=$($OLW compile 2>&1) || _CAR_RC=$?
     echo "$COMPILE_OUT2"
+    check "compile after rejection exits 0" "test $_CAR_RC -eq 0"
     # We can't easily inspect the prompt, but compile should succeed without crash
     check "recompile after rejection completes" \
         "! echo \"$COMPILE_OUT2\" | grep -qiE 'traceback|fatal'"
@@ -717,23 +862,34 @@ conn.commit()
 conn.close()
 PYEOF
 
-STATUS_BLOCKED=$($OLW status 2>&1 || true)
+_SB_RC=0
+STATUS_BLOCKED=$($OLW status 2>&1) || _SB_RC=$?
+check "status (with block) exits 0" "test $_SB_RC -eq 0"
 _TMP=$(mktemp); echo "$STATUS_BLOCKED" > "$_TMP"
 check "status shows blocked concept" \
     "grep -qiE 'blocked|Fake Blocked' \"$_TMP\""
 rm -f "$_TMP"
 
-UNBLOCK_OUT=$($OLW unblock "Fake Blocked Concept" 2>&1 || true)
+_UB_RC=0
+UNBLOCK_OUT=$($OLW unblock "Fake Blocked Concept" 2>&1) || _UB_RC=$?
 echo "$UNBLOCK_OUT"
+check "unblock exits 0" "test $_UB_RC -eq 0"
 check "unblock completes without error" \
     "! echo \"$UNBLOCK_OUT\" | grep -qiE 'traceback|error'"
+# Capture status output, then grep — prevents false-pass if status itself crashes
+# (previous inline-pipe idiom let a status crash look like "no match" via pipefail disable in check())
+_SAU_RC=0
+STATUS_AFTER_UNBLOCK=$($OLW status 2>&1) || _SAU_RC=$?
+check "status (after unblock) exits 0" "test $_SAU_RC -eq 0"
 check "concept no longer blocked after unblock" \
-    "! $OLW status 2>&1 | grep -qiE 'Fake Blocked'"
+    "! echo \"\$STATUS_AFTER_UNBLOCK\" | grep -qiE 'Fake Blocked'"
 
 # ── olw maintain ─────────────────────────────────────────────────────────────
 header "olw maintain"
-MAINTAIN_OUT=$($OLW maintain 2>&1 || true)
+_M_RC=0
+MAINTAIN_OUT=$($OLW maintain 2>&1) || _M_RC=$?
 echo "$MAINTAIN_OUT"
+check "maintain exits 0" "test $_M_RC -eq 0"
 _TMP=$(mktemp); echo "$MAINTAIN_OUT" > "$_TMP"
 check "maintain runs without fatal error" \
     "! grep -qiE 'traceback|exception|fatal' \"$_TMP\""
@@ -741,7 +897,9 @@ check "maintain reports health or quality info" \
     "grep -qiE 'health|quality|lint|stub|orphan|issue|ok' \"$_TMP\""
 rm -f "$_TMP"
 
-MAINTAIN_DRY_OUT=$($OLW maintain --dry-run 2>&1 || true)
+_MD_RC=0
+MAINTAIN_DRY_OUT=$($OLW maintain --dry-run 2>&1) || _MD_RC=$?
+check "maintain --dry-run exits 0" "test $_MD_RC -eq 0"
 _TMP=$(mktemp); echo "$MAINTAIN_DRY_OUT" > "$_TMP"
 check "maintain --dry-run completes" \
     "! grep -qiE 'traceback|fatal' \"$_TMP\""
@@ -755,8 +913,10 @@ FIRST_WIKI=$(find "$VAULT_DIR/wiki" -maxdepth 1 -name "*.md" \
 
 if [[ -n "$FIRST_WIKI" ]]; then
     echo -e "\n[[Nonexistent Stub Topic]]" >> "$FIRST_WIKI"
-    STUB_OUT=$($OLW maintain --fix 2>&1 || true)
+    _STUB_RC=0
+    STUB_OUT=$($OLW maintain --fix 2>&1) || _STUB_RC=$?
     echo "$STUB_OUT"
+    check "maintain --fix (stub) exits 0" "test $_STUB_RC -eq 0"
     _TMP=$(mktemp); echo "$STUB_OUT" > "$_TMP"
     check "maintain --fix runs without fatal error" \
         "! grep -qiE 'traceback|fatal' \"$_TMP\""
@@ -774,6 +934,21 @@ conn.close()
 " 2>/dev/null || echo 0)
     check "maintain --fix created stub draft or DB entry" \
         "test '$STUB_DRAFT_COUNT' -gt 0 || test '$STUB_DB_COUNT' -gt 0"
+    # No stub should have a double .md.md extension (bug: model emits [[raw-note.md]] links)
+    DOUBLE_MD_STUBS=$(find "$VAULT_DIR/wiki/.drafts" -name "*.md.md" 2>/dev/null | wc -l | tr -d ' ')
+    check "no stub has double .md.md extension" "test '$DOUBLE_MD_STUBS' -eq 0"
+    # Stub shape — create_stubs writes to drafts_dir with status=stub, confidence=0.0, [!info] callout.
+    # Filename is sanitize_filename("Nonexistent Stub Topic") + .md.
+    _STUB_FILE=$(find "$VAULT_DIR/wiki/.drafts" -iname 'nonexistent*stub*topic*.md' 2>/dev/null | head -1)
+    if [[ -n "$_STUB_FILE" ]]; then
+        check "stub body has [!info] callout" "grep -qF '[!info]' \"$_STUB_FILE\""
+        check "stub frontmatter has status: stub" \
+            "grep -qE '^status: stub' \"$_STUB_FILE\""
+        check "stub frontmatter has confidence: 0 or 0.0" \
+            "grep -qE '^confidence: 0(\.0)?\$' \"$_STUB_FILE\""
+    else
+        info "Stub shape check skipped (no stub file matching nonexistent*stub*topic*.md)"
+    fi
     rm -f "$_TMP"
     # Restore the file
     # (truncate last line — safe enough for smoke test purposes)
@@ -781,6 +956,119 @@ conn.close()
 else
     pass "stub creation test skipped (no wiki article available)"
 fi
+
+# ── olw maintain --fix (alias-based link repair, issue #29) ──────────────────
+header "olw maintain --fix (alias link repair, issue #29)"
+# Deterministic setup: inject a known concept + alias + published article directly,
+# so the test doesn't depend on what the LLM happened to produce earlier in the run.
+REPAIR_WIKI=$(find "$VAULT_DIR/wiki" -maxdepth 1 -name "*.md" \
+    ! -name "index.md" ! -name "log.md" 2>/dev/null | head -1)
+
+if [[ -n "$REPAIR_WIKI" ]]; then
+    # 1. Register a synthetic concept and unambiguous alias in the DB
+    python3 - <<PYEOF
+import sqlite3
+conn = sqlite3.connect("$VAULT_DIR/.olw/state.db")
+# Insert concept if not present (idempotent); schema: (name, source_path)
+conn.execute("""
+    INSERT OR IGNORE INTO concepts (name, source_path)
+    VALUES ('Smoke Test Concept', 'raw/smoke-test-concept.md')
+""")
+# Register unambiguous alias
+conn.execute("""
+    INSERT OR IGNORE INTO concept_aliases (concept_name, alias)
+    VALUES ('Smoke Test Concept', 'STC alias')
+""")
+conn.commit()
+conn.close()
+PYEOF
+
+    # 2. Write a minimal published article for the concept so fix_broken_links
+    #    considers it a valid repair target (not just stub-worthy)
+    _STC_ARTICLE="$VAULT_DIR/wiki/Smoke Test Concept.md"
+    cat > "$_STC_ARTICLE" <<'MDEOF'
+---
+title: Smoke Test Concept
+status: published
+tags: [test]
+sources: []
+confidence: 1.0
+created: 2026-01-01
+updated: 2026-01-01
+---
+
+Synthetic article for smoke test alias repair verification.
+MDEOF
+
+    # 3. Inject [[STC alias]] as an alias-form link into a real published article
+    echo -e "\n[[STC alias]] — this alias link should be normalized by maintain --fix." >> "$REPAIR_WIKI"
+
+    _REP_RC=0
+    REPAIR_OUT=$($OLW maintain --fix 2>&1) || _REP_RC=$?
+    echo "$REPAIR_OUT"
+    check "maintain --fix (alias repair) exits 0" "test $_REP_RC -eq 0"
+
+    _TMP=$(mktemp); echo "$REPAIR_OUT" > "$_TMP"
+    check "maintain --fix runs without fatal error (alias repair, issue #29)" \
+        "! grep -qiE 'traceback|fatal' \"$_TMP\""
+    rm -f "$_TMP"
+
+    # 4. Verify [[STC alias]] was rewritten to [[Smoke Test Concept|STC alias]]
+    check "maintain --fix rewrote alias link to canonical form (issue #29)" \
+        "grep -qF '[[Smoke Test Concept|STC alias]]' \"$REPAIR_WIKI\""
+
+    # Cleanup injected content and synthetic article
+    sed -i '' '$ d' "$REPAIR_WIKI" 2>/dev/null || sed -i '$ d' "$REPAIR_WIKI" 2>/dev/null || true
+    rm -f "$_STC_ARTICLE"
+    python3 - <<PYEOF
+import sqlite3
+conn = sqlite3.connect("$VAULT_DIR/.olw/state.db")
+conn.execute("DELETE FROM concept_aliases WHERE alias = 'STC alias'")
+conn.execute("DELETE FROM concepts WHERE name = 'Smoke Test Concept' AND source_path = 'raw/smoke-test-concept.md'")
+conn.commit()
+conn.close()
+PYEOF
+else
+    pass "alias repair test skipped (no wiki article available)"
+fi
+
+# ── maintain --fix idempotency ────────────────────────────────────────────────
+# After the two maintain --fix runs above, a third run must make zero changes.
+# Guards against double-rewrite bugs (alias normalization firing twice, stubs
+# re-created, etc). Snapshot published markdown hashes, run again, compare.
+header "maintain --fix idempotency"
+_SNAP_BEFORE=$(find "$VAULT_DIR/wiki" -type f -name '*.md' \
+    -not -path '*/.drafts/*' -exec shasum {} \; 2>/dev/null | sort)
+_IDEMP_RC=0
+$OLW maintain --fix > /dev/null 2>&1 || _IDEMP_RC=$?
+check "maintain --fix (idempotency run) exits 0" "test $_IDEMP_RC -eq 0"
+_SNAP_AFTER=$(find "$VAULT_DIR/wiki" -type f -name '*.md' \
+    -not -path '*/.drafts/*' -exec shasum {} \; 2>/dev/null | sort)
+check "maintain --fix is idempotent (no changes on second run)" \
+    "test \"\$_SNAP_BEFORE\" = \"\$_SNAP_AFTER\""
+
+# ── compile --legacy smoke pass ───────────────────────────────────────────────
+# Legacy two-step LLM path is shipped but never exercised by smoke. Run one
+# minimal invocation to guard against complete-bitrot. Don't assert on quality —
+# small-model legacy output is noisy — just "ran, produced a draft".
+header "olw compile --legacy"
+# Force one note back to 'ingested' so legacy has something to compile
+python3 - <<PYEOF
+import sqlite3
+conn = sqlite3.connect("$VAULT_DIR/.olw/state.db")
+conn.execute(
+    "UPDATE raw_notes SET status='ingested' WHERE path='raw/machine-learning-basics.md'"
+)
+conn.commit()
+conn.close()
+PYEOF
+
+_LEGACY_RC=0
+LEGACY_OUT=$($OLW compile --legacy 2>&1) || _LEGACY_RC=$?
+echo "$LEGACY_OUT"
+# Legacy two-step planning is prone to small-model JSON validation failures.
+# Exit-0 is the bit-rot guard — draft production is model-dependent, not asserted.
+check "compile --legacy exits 0" "test $_LEGACY_RC -eq 0"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 header "Results"

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -258,6 +258,28 @@ def _init_existing(vault: Path, non_interactive: bool) -> None:
 
     _write_vault_schema(vault)
     _write_index(vault)
+    _cleanup_legacy_index(vault)
+
+
+def _cleanup_legacy_index(vault: Path) -> None:
+    """Remove wiki/INDEX.md if it's the bootstrap stub and is distinct from wiki/index.md."""
+    old = vault / "wiki" / "INDEX.md"
+    new = vault / "wiki" / "index.md"
+    if not old.exists():
+        return
+    # On case-insensitive FS old and new are the same file — don't delete
+    if new.exists():
+        try:
+            if old.samefile(new):
+                return
+        except OSError:
+            return
+    try:
+        content = old.read_text(encoding="utf-8")
+        if content == _INDEX_STUB:
+            old.unlink()
+    except Exception:
+        pass
 
 
 def _write_vault_schema(vault: Path) -> None:
@@ -277,14 +299,17 @@ def _write_vault_schema(vault: Path) -> None:
         )
 
 
+_INDEX_STUB = (
+    "---\ntitle: Index\ntags: [index]\nstatus: published\n---\n\n"
+    "# Wiki Index\n\n_Updated automatically by olw._\n"
+)
+
+
 def _write_index(vault: Path) -> None:
-    index = vault / "wiki" / "INDEX.md"
+    index = vault / "wiki" / "index.md"
     if not index.exists():
         index.parent.mkdir(parents=True, exist_ok=True)
-        index.write_text(
-            "---\ntitle: Index\ntags: [index]\nstatus: published\n---\n\n"
-            "# Wiki Index\n\n_Updated automatically by olw._\n"
-        )
+        index.write_text(_INDEX_STUB)
 
 
 # ── setup ─────────────────────────────────────────────────────────────────────
@@ -1551,7 +1576,13 @@ def maintain(vault_str, fix, stubs_only, dry_run):
     """Wiki maintenance: lint, stub creation, orphan suggestions, concept merge hints."""
     from .pipeline.lint import run_lint
     from .pipeline.lock import pipeline_lock
-    from .pipeline.maintain import create_stubs, suggest_concept_merges, suggest_orphan_links
+    from .pipeline.maintain import (
+        create_stubs,
+        fix_broken_links,
+        normalize_published_alias_links,
+        suggest_concept_merges,
+        suggest_orphan_links,
+    )
 
     config = _load_config(vault_str)
     db = _load_db(config)
@@ -1607,17 +1638,41 @@ def maintain(vault_str, fix, stubs_only, dry_run):
                 console.print(f"  [bold]{iss.issue_type}[/bold]{fix_tag}  {iss.path}")
                 console.print(f"    {iss.description}")
 
-        # Stub creation
+        # Alias link normalization in published articles (fix [[Alias]] → [[Canonical|Alias]])
+        # Runs independently of broken-link detection: lint resolves aliases so they never
+        # appear as broken, but published articles may still have raw alias-form links.
+        if fix and not stubs_only:
+            alias_normalized = normalize_published_alias_links(config, db, dry_run=dry_run)
+            if alias_normalized:
+                console.print(
+                    f"\n[green]Normalized alias links in {alias_normalized} article(s).[/green]"
+                )
+
+        # Broken link repair + stub creation
         broken = [i for i in result.issues if i.issue_type == "broken_link"]
         if broken:
-            if fix and not dry_run:
+            if fix and not stubs_only:
+                repair = fix_broken_links(config, db, broken, dry_run=dry_run)
+                if repair.repaired:
+                    console.print(f"\n[green]Repaired {repair.repaired} broken link(s).[/green]")
+                remaining = repair.still_broken
+                if remaining and not dry_run:
+                    created = create_stubs(config, db, broken_link_issues=remaining)
+                    if created:
+                        console.print(f"[green]Created {len(created)} stub(s).[/green]")
+                elif remaining:
+                    console.print(
+                        f"[dim]{len(remaining)} link(s) unresolvable"
+                        f" — stubs would be created.[/dim]"
+                    )
+            elif fix:
                 created = create_stubs(config, db, broken_link_issues=broken)
                 if created:
                     console.print(f"\n[green]Created {len(created)} stub(s).[/green]")
             else:
                 console.print(
                     f"\n[dim]{len(broken)} broken link(s) — "
-                    f"run [bold]olw maintain --fix[/bold] to create stubs.[/dim]"
+                    f"run [bold]olw maintain --fix[/bold] to repair or create stubs.[/dim]"
                 )
 
         # Orphan suggestions

--- a/src/obsidian_llm_wiki/indexer.py
+++ b/src/obsidian_llm_wiki/indexer.py
@@ -63,7 +63,7 @@ def generate_index(config: Config, db: StateDB) -> Path:
     known_titles = {a.title for a in concept_articles}
     if config.wiki_dir.exists():
         for md in sorted(config.wiki_dir.glob("*.md")):
-            if md.name == "index.md" or md.name == "INDEX.md" or md.name == "log.md":
+            if md.name == "index.md" or md.name == "log.md":
                 continue
             try:
                 meta, _ = parse_note(md)

--- a/src/obsidian_llm_wiki/indexer.py
+++ b/src/obsidian_llm_wiki/indexer.py
@@ -63,7 +63,8 @@ def generate_index(config: Config, db: StateDB) -> Path:
     known_titles = {a.title for a in concept_articles}
     if config.wiki_dir.exists():
         for md in sorted(config.wiki_dir.glob("*.md")):
-            if md.name == "index.md" or md.name == "log.md":
+            # Skip index + log (any case, covers legacy INDEX.md from pre-v0.5 vaults)
+            if md.name.lower() in ("index.md", "log.md"):
                 continue
             try:
                 meta, _ = parse_note(md)

--- a/src/obsidian_llm_wiki/models.py
+++ b/src/obsidian_llm_wiki/models.py
@@ -18,11 +18,24 @@ from .sanitize import sanitize_tags
 # ── LLM Output Models (keep schemas small and flat) ──────────────────────────
 
 
+class Concept(BaseModel):
+    """A concept extracted from a raw note, with optional surface-form aliases."""
+
+    name: str = Field(description="Canonical concept name")
+    aliases: list[str] = Field(
+        default_factory=list,
+        description=(
+            "3-5 short surface forms a writer uses in running text "
+            "(abbreviations, short names, translations). Empty list if none."
+        ),
+    )
+
+
 class AnalysisResult(BaseModel):
     """Returned by fast model when analyzing a raw note."""
 
     summary: str = Field(description="2-3 sentence plain-English summary")
-    key_concepts: list[str] = Field(description="Main topics/concepts found (max 8)")
+    concepts: list[Concept] = Field(description="Main topics/concepts found (max 8)")
     suggested_topics: list[str] = Field(
         description="Titles of wiki articles this note should feed into (max 5)"
     )

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -37,6 +37,7 @@ from ..vault import (
     ensure_wikilinks,
     extract_wikilinks,
     list_wiki_articles,
+    normalize_wikilinks,
     parse_note,
     sanitize_filename,
     write_note,
@@ -234,6 +235,8 @@ def _write_draft(
     confidence: float = 0.5,
     existing_meta: dict | None = None,
     existing_titles: list[str] | None = None,
+    concept_aliases: list[str] | None = None,
+    alias_map: dict[str, str] | None = None,
 ) -> Path:
     """Write SingleArticle to wiki/.drafts/ and record in state DB."""
     config.drafts_dir.mkdir(parents=True, exist_ok=True)
@@ -243,6 +246,10 @@ def _write_draft(
 
     # Inject wikilinks for known article titles mentioned in body
     body = ensure_wikilinks(content_result.content, existing_titles or [])
+    # Normalize alias-based links to canonical targets
+    if alias_map:
+        known = {t.lower() for t in (existing_titles or [])}
+        body = normalize_wikilinks(body, alias_map, known)
     body = _inject_body_sections(body, source_paths, config)
 
     # Prepend quality annotations (invisible HTML comments, stripped on approve)
@@ -263,6 +270,7 @@ def _write_draft(
         confidence=confidence,
         is_draft=True,
         existing_meta=existing_meta,
+        aliases=concept_aliases or [],
     )
 
     post = fm_lib.Post(body, **meta)
@@ -359,6 +367,8 @@ def compile_concepts(
     existing_titles = [t for t, _ in list_wiki_articles(config.wiki_dir)]
     vault_schema = _load_vault_schema(config)
     total = len(concept_names)
+    # Build alias resolution map once per compile run
+    alias_map = db.list_alias_map()
 
     if dry_run:
         for name in concept_names:
@@ -432,6 +442,8 @@ def compile_concepts(
                 confidence=0.0,
                 existing_meta=existing_meta,
                 existing_titles=existing_titles,
+                concept_aliases=db.get_aliases(name),
+                alias_map=alias_map,
             )
             draft_paths.append(draft_path)
             db.delete_stub(name)
@@ -500,6 +512,8 @@ def compile_concepts(
             confidence=confidence,
             existing_meta=existing_meta,
             existing_titles=existing_titles,
+            concept_aliases=db.get_aliases(name),
+            alias_map=alias_map,
         )
         draft_paths.append(draft_path)
         compiled_sources.update(resolved_paths)

--- a/src/obsidian_llm_wiki/pipeline/ingest.py
+++ b/src/obsidian_llm_wiki/pipeline/ingest.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ..config import Config
-from ..models import AnalysisResult, RawNoteRecord
+from ..models import AnalysisResult, Concept, RawNoteRecord
 from ..protocols import LLMClientProtocol
 from ..state import StateDB
 from ..structured_output import request_structured
@@ -51,6 +51,9 @@ def _build_analysis_prompt(
     return (
         f"Analyze this note{label} and extract structured metadata.\n\n"
         f"Existing wiki concepts (reuse these names where applicable): {concepts_hint}\n\n"
+        f"For each concept, provide 3-5 short surface forms used in running text "
+        f"(abbreviations, short names). Example: name='Program Counter (PC)', "
+        f"aliases=['PC', 'program counter']. Use empty list if no natural aliases exist.\n\n"
         f"NOTE CONTENT:\n{body}"
     )
 
@@ -59,19 +62,33 @@ def _merge_chunk_results(results: list[AnalysisResult]) -> AnalysisResult:
     """Merge AnalysisResults from multiple chunks into one.
 
     Concepts and topics: union (deduplicated, insertion order preserved).
+    Aliases for the same concept are merged across chunks.
     Summary: first chunk's (intro is most representative).
     Quality: minimum across chunks (conservative).
     """
     if len(results) == 1:
         return results[0]
 
-    seen_concepts: set[str] = set()
-    all_concepts: list[str] = []
+    # Dedup concepts by canonical name (case-insensitive), merge aliases
+    seen: dict[str, list[str]] = {}  # lower(name) -> accumulated aliases
+    order: list[str] = []  # canonical names in insertion order
+    canonical_by_lower: dict[str, str] = {}
+
     for r in results:
-        for c in r.key_concepts:
-            if c.lower() not in seen_concepts:
-                seen_concepts.add(c.lower())
-                all_concepts.append(c)
+        for c in r.concepts:
+            key = c.name.lower()
+            if key not in seen:
+                seen[key] = list(c.aliases)
+                order.append(key)
+                canonical_by_lower[key] = c.name
+            else:
+                existing_lower = {a.lower() for a in seen[key]}
+                for a in c.aliases:
+                    if a.lower() not in existing_lower:
+                        seen[key].append(a)
+                        existing_lower.add(a.lower())
+
+    all_concepts = [Concept(name=canonical_by_lower[k], aliases=seen[k]) for k in order][:8]
 
     seen_topics: set[str] = set()
     all_topics: list[str] = []
@@ -84,12 +101,11 @@ def _merge_chunk_results(results: list[AnalysisResult]) -> AnalysisResult:
     quality_rank = {"high": 2, "medium": 1, "low": 0}
     min_result = min(results, key=lambda r: quality_rank.get(r.quality, 1))
 
-    # Use the first non-None detected language across chunks
     merged_language = next((r.language for r in results if r.language), None)
 
     return AnalysisResult(
         summary=results[0].summary,
-        key_concepts=all_concepts[:8],
+        concepts=all_concepts,
         suggested_topics=all_topics[:5],
         quality=min_result.quality,
         language=merged_language,
@@ -162,24 +178,74 @@ def _analyze_body(
     return _merge_chunk_results(results)
 
 
-def _normalize_concept_names(raw_names: list[str], db: StateDB) -> list[str]:
-    """Case-insensitive match against existing canonical concept names.
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "but",
+        "is",
+        "it",
+        "in",
+        "on",
+        "at",
+        "to",
+        "by",
+        "for",
+        "of",
+        "as",
+        "from",
+        "with",
+        "this",
+        "that",
+        "these",
+        "those",
+        "be",
+        "are",
+    }
+)
 
-    If a name matches an existing concept (case-insensitive), reuse the canonical form.
-    Otherwise accept as-is. Deduplicates by canonical name.
+
+def _validate_aliases(canonical: str, raw_aliases: list[str]) -> list[str]:
+    """Filter LLM-produced aliases: remove too-short, stopwords, self-matches, duplicates."""
+    seen = {canonical.lower()}
+    valid: list[str] = []
+    for alias in raw_aliases:
+        a = alias.strip()
+        if not a or a.lower() in seen:
+            continue
+        if len(a) < 2:
+            continue
+        if len(a) <= 3 and not a.isupper():
+            continue
+        if a.lower() in _STOPWORDS:
+            continue
+        seen.add(a.lower())
+        valid.append(a)
+    return valid[:5]
+
+
+def _normalize_concepts(raw_concepts: list[Concept], db: StateDB) -> list[tuple[str, list[str]]]:
+    """Case-insensitive dedup against existing canonical concept names.
+
+    Returns (canonical_name, validated_aliases) pairs.
     """
     existing = {n.lower(): n for n in db.list_all_concept_names()}
     seen: set[str] = set()
-    normalized: list[str] = []
-    for name in raw_names:
-        name = name.strip()
+    result: list[tuple[str, list[str]]] = []
+    for concept in raw_concepts:
+        name = concept.name.strip()
         if not name:
             continue
         canonical = existing.get(name.lower(), name)
-        if canonical not in seen:
-            seen.add(canonical)
-            normalized.append(canonical)
-    return normalized
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        aliases = _validate_aliases(canonical, concept.aliases)
+        result.append((canonical, aliases))
+    return result
 
 
 _HEADER_SCAN_LINES = 30  # only strip short lines from the opening section
@@ -249,7 +315,7 @@ def _create_source_summary_page(
 
     # Build concept list as [[wikilinks]]
     concept_lines = "\n".join(
-        f"- [[{sanitize_wikilink_target(c)}]]" for c in result.key_concepts[:8] if c.strip()
+        f"- [[{sanitize_wikilink_target(c.name)}]]" for c in result.concepts[:8] if c.name.strip()
     )
 
     out_meta: dict = {
@@ -382,8 +448,12 @@ def ingest_note(
 
     # Normalize concept names against existing canonical names, store linkages
     max_concepts = config.pipeline.max_concepts_per_source
-    normalized_concepts = _normalize_concept_names(result.key_concepts[:max_concepts], db)
-    db.upsert_concepts(rel_path, normalized_concepts)
+    normalized = _normalize_concepts(result.concepts[:max_concepts], db)
+    canonical_names = [name for name, _ in normalized]
+    db.upsert_concepts(rel_path, canonical_names)
+    for canonical, aliases in normalized:
+        if aliases:
+            db.upsert_aliases(canonical, aliases)
 
     # Create source summary page in wiki/sources/ (no extra LLM call)
     try:
@@ -392,7 +462,10 @@ def ingest_note(
         log.warning("Source summary page failed for %s: %s", path.name, e)
 
     log.info(
-        "Ingested: %s (quality=%s, concepts=%s)", path.name, result.quality, result.key_concepts[:3]
+        "Ingested: %s (quality=%s, concepts=%s)",
+        path.name,
+        result.quality,
+        [c.name for c in result.concepts[:3]],
     )
     return result
 

--- a/src/obsidian_llm_wiki/pipeline/lint.py
+++ b/src/obsidian_llm_wiki/pipeline/lint.py
@@ -107,7 +107,12 @@ def _build_title_index(config: Config, db: StateDB | None = None) -> dict[str, P
             title = meta.get("title", "")
             if title:
                 index[title.lower()] = md
-            for alias in meta.get("aliases", []):
+            aliases = meta.get("aliases", [])
+            if isinstance(aliases, str):
+                aliases = [aliases]
+            elif not isinstance(aliases, list):
+                aliases = []
+            for alias in aliases:
                 if isinstance(alias, str) and alias.strip():
                     alias_targets.setdefault(alias.strip().lower(), []).append(md)
         except Exception:

--- a/src/obsidian_llm_wiki/pipeline/lint.py
+++ b/src/obsidian_llm_wiki/pipeline/lint.py
@@ -89,9 +89,15 @@ def _body_hash(body: str) -> str:
     return hashlib.sha256(body.encode()).hexdigest()
 
 
-def _build_title_index(config: Config) -> dict[str, Path]:
-    """Map lowercase title/stem → path for every published wiki page."""
+def _build_title_index(config: Config, db: StateDB | None = None) -> dict[str, Path]:
+    """Map lowercase title/stem → path for every published wiki page.
+
+    Also indexes frontmatter aliases and (when db provided) DB alias map.
+    Ambiguous aliases (same alias → multiple pages) are excluded so they stay broken.
+    """
     index: dict[str, Path] = {}
+    alias_targets: dict[str, list[Path]] = {}  # alias_lower → candidate paths
+
     for md in config.wiki_dir.rglob("*.md"):
         if ".drafts" in md.parts:
             continue
@@ -101,8 +107,25 @@ def _build_title_index(config: Config) -> dict[str, Path]:
             title = meta.get("title", "")
             if title:
                 index[title.lower()] = md
+            for alias in meta.get("aliases", []):
+                if isinstance(alias, str) and alias.strip():
+                    alias_targets.setdefault(alias.strip().lower(), []).append(md)
         except Exception:
             pass
+
+    # Add DB alias map: alias → canonical title → path (via title index)
+    if db is not None:
+        for alias_lower, canonical in db.list_alias_map().items():
+            target = index.get(canonical.lower())
+            if target is not None:
+                alias_targets.setdefault(alias_lower, []).append(target)
+
+    # Commit unambiguous aliases to index (don't overwrite canonical title/stem entries)
+    for alias_lower, targets in alias_targets.items():
+        unique = list({id(t): t for t in targets}.values())
+        if len(unique) == 1 and alias_lower not in index:
+            index[alias_lower] = unique[0]
+
     return index
 
 
@@ -154,7 +177,7 @@ def _all_wiki_pages(config: Config) -> list[Path]:
 def run_lint(config: Config, db: StateDB, fix: bool = False) -> LintResult:
     issues: list[LintIssue] = []
 
-    title_index = _build_title_index(config)
+    title_index = _build_title_index(config, db=db)
     inbound_index = _build_inbound_index(config)
 
     # DB records keyed by vault-relative path

--- a/src/obsidian_llm_wiki/pipeline/maintain.py
+++ b/src/obsidian_llm_wiki/pipeline/maintain.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
@@ -20,7 +21,14 @@ import frontmatter as fm_lib
 from ..config import Config
 from ..models import LintIssue
 from ..state import StateDB
-from ..vault import atomic_write, parse_note, sanitize_filename
+from ..vault import (
+    atomic_write,
+    list_wiki_articles,
+    normalize_wikilinks,
+    parse_note,
+    sanitize_filename,
+    write_note,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +39,149 @@ Add raw notes about this topic to `raw/` and run `olw compile` to generate a ful
 """
 
 _CONCEPT_MERGE_THRESHOLD = 0.7
+
+_WIKILINK_REPAIR_RE = re.compile(r"\[\[([^\]|#]+?)(?:#([^\]|]*))?(?:\|([^\]]*))?\]\]")
+
+
+@dataclass
+class FixReport:
+    repaired: int = 0
+    repaired_links: list[tuple[str, str, str]] = field(default_factory=list)
+    still_broken: list[LintIssue] = field(default_factory=list)
+    skipped_files: list[Path] = field(default_factory=list)
+
+
+def fix_broken_links(
+    config: Config,
+    db: StateDB,
+    broken_link_issues: list[LintIssue],
+    dry_run: bool = False,
+) -> FixReport:
+    """Rewrite broken [[Alias]] links to [[Canonical|Alias]] using the alias map.
+
+    Only unambiguous matches are rewritten. Ambiguous or unknown links fall through
+    to still_broken for stub creation.
+    """
+    report = FixReport()
+
+    if not broken_link_issues:
+        return report
+
+    alias_map = db.list_alias_map()
+    if not alias_map:
+        report.still_broken = list(broken_link_issues)
+        return report
+
+    # Build set of known published article titles (lowercase) so we don't rewrite good links
+    known_lower = {t.lower() for t, _ in list_wiki_articles(config.wiki_dir)}
+
+    # Group issues by source file for one write per file
+    issues_by_file: dict[str, list[LintIssue]] = {}
+    for issue in broken_link_issues:
+        issues_by_file.setdefault(issue.path, []).append(issue)
+
+    for rel_path, file_issues in issues_by_file.items():
+        page = config.vault / rel_path
+        try:
+            meta, body = parse_note(page)
+        except Exception as exc:
+            log.warning("fix_broken_links: skipping %s — parse error: %s", rel_path, exc)
+            report.skipped_files.append(page)
+            report.still_broken.extend(file_issues)
+            continue
+
+        original_body = body
+        repaired_in_file: list[tuple[str, str]] = []
+        still_broken_in_file: list[LintIssue] = []
+
+        for issue in file_issues:
+            target = _extract_link_target(issue.description)
+            if target is None:
+                still_broken_in_file.append(issue)
+                continue
+
+            # Skip if target is already a known title (shouldn't be in broken list, but guard)
+            if target.lower() in known_lower:
+                still_broken_in_file.append(issue)
+                continue
+
+            canonical = alias_map.get(target.lower())
+            if canonical is None or canonical.lower() not in known_lower:
+                still_broken_in_file.append(issue)
+                continue
+
+            # Rewrite all occurrences of [[target ...]] → [[canonical|target]]
+            def _make_rewriter(t: str, canon: str):
+                def _rewrite(m: re.Match) -> str:
+                    if m.group(1).strip().lower() != t.lower():
+                        return m.group(0)
+                    fragment = m.group(2)
+                    display = m.group(3) if m.group(3) is not None else m.group(1).strip()
+                    frag_part = f"#{fragment}" if fragment else ""
+                    return f"[[{canon}{frag_part}|{display}]]"
+
+                return _rewrite
+
+            new_body = _WIKILINK_REPAIR_RE.sub(_make_rewriter(target, canonical), body)
+            if new_body != body:
+                repaired_in_file.append((f"[[{target}]]", f"[[{canonical}|{target}]]"))
+                body = new_body
+            else:
+                still_broken_in_file.append(issue)
+
+        if body != original_body:
+            if dry_run:
+                for old, new in repaired_in_file:
+                    log.info("dry-run: would rewrite %s → %s in %s", old, new, rel_path)
+            else:
+                write_note(page, meta, body)
+            for old, new in repaired_in_file:
+                report.repaired += 1
+                report.repaired_links.append((rel_path, old, new))
+
+        report.still_broken.extend(still_broken_in_file)
+
+    return report
+
+
+def normalize_published_alias_links(
+    config: Config,
+    db: StateDB,
+    dry_run: bool = False,
+) -> int:
+    """Rewrite alias-form [[Alias]] links in published articles to [[Canonical|Alias]].
+
+    Complements compile's normalize_wikilinks pass: articles published before an alias
+    was registered never got that normalization. This pass runs on all published articles.
+
+    Only unambiguous alias rewrites are applied. Returns number of files modified.
+    """
+    alias_map = db.list_alias_map()
+    if not alias_map:
+        return 0
+
+    known_titles = {t.lower() for t, _ in list_wiki_articles(config.wiki_dir)}
+    modified = 0
+
+    for _title, path in list_wiki_articles(config.wiki_dir):
+        try:
+            meta, body = parse_note(path)
+        except Exception as exc:
+            log.warning("normalize_published_alias_links: skipping %s — %s", path.name, exc)
+            continue
+
+        new_body = normalize_wikilinks(body, alias_map, known_titles)
+        if new_body == body:
+            continue
+
+        if dry_run:
+            log.info("dry-run: would normalize alias links in %s", path.name)
+        else:
+            write_note(path, meta, new_body)
+            log.info("Normalized alias links in %s", path.name)
+        modified += 1
+
+    return modified
 
 
 def create_stubs(
@@ -68,6 +219,11 @@ def create_stubs(
         if not target:
             # Fall back to path stem
             target = Path(issue.path).stem
+        # Strip trailing .md — model sometimes generates [[raw-note.md]] wikilinks
+        if target.lower().endswith(".md"):
+            target = target[:-3]
+        if not target:
+            continue
 
         if target in seen:
             continue

--- a/src/obsidian_llm_wiki/pipeline/maintain.py
+++ b/src/obsidian_llm_wiki/pipeline/maintain.py
@@ -22,6 +22,8 @@ from ..config import Config
 from ..models import LintIssue
 from ..state import StateDB
 from ..vault import (
+    _mask_code_blocks,
+    _restore_code_blocks,
     atomic_write,
     list_wiki_articles,
     normalize_wikilinks,
@@ -91,6 +93,8 @@ def fix_broken_links(
             continue
 
         original_body = body
+        # Mask code fences so repair doesn't rewrite [[...]] inside ```code``` or `inline`.
+        masked_body, spans = _mask_code_blocks(body)
         repaired_in_file: list[tuple[str, str]] = []
         still_broken_in_file: list[LintIssue] = []
 
@@ -122,12 +126,14 @@ def fix_broken_links(
 
                 return _rewrite
 
-            new_body = _WIKILINK_REPAIR_RE.sub(_make_rewriter(target, canonical), body)
-            if new_body != body:
+            new_masked = _WIKILINK_REPAIR_RE.sub(_make_rewriter(target, canonical), masked_body)
+            if new_masked != masked_body:
                 repaired_in_file.append((f"[[{target}]]", f"[[{canonical}|{target}]]"))
-                body = new_body
+                masked_body = new_masked
             else:
                 still_broken_in_file.append(issue)
+
+        body = _restore_code_blocks(masked_body, spans)
 
         if body != original_body:
             if dry_run:

--- a/src/obsidian_llm_wiki/pipeline/query.py
+++ b/src/obsidian_llm_wiki/pipeline/query.py
@@ -36,7 +36,7 @@ def _load_index(config: Config) -> str:
     return index_path.read_text(encoding="utf-8")
 
 
-def _find_page(config: Config, title: str) -> Path | None:
+def _find_page(config: Config, title: str, db: StateDB | None = None) -> Path | None:
     """Resolve a title to a file path. Checks wiki/ root then sources/."""
     # Exact filename match (wiki root)
     candidate = config.wiki_dir / f"{title}.md"
@@ -56,14 +56,19 @@ def _find_page(config: Config, title: str) -> Path | None:
                 return md
         except Exception:
             pass
+    # Alias resolution fallback
+    if db is not None:
+        canonical = db.resolve_alias(title)
+        if canonical is not None:
+            return _find_page(config, canonical, db=None)
     return None
 
 
-def _load_pages(config: Config, page_titles: list[str]) -> str:
+def _load_pages(config: Config, page_titles: list[str], db: StateDB | None = None) -> str:
     """Return concatenated content of selected pages."""
     parts: list[str] = []
     for title in page_titles[:MAX_PAGES]:
-        page = _find_page(config, title)
+        page = _find_page(config, title, db=db)
         if page is None:
             continue
         try:
@@ -114,7 +119,7 @@ def run_query(
     )
 
     # Step 2: load selected pages
-    context = _load_pages(config, selection.pages)
+    context = _load_pages(config, selection.pages, db=db)
     if not context:
         context = "(No matching wiki pages found.)"
 

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -192,12 +192,13 @@ class StateDB:
                         "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, 3)"
                     )
                 current_version = 3
-            # Existing DB with no version tracking — start from 0, apply all migrations.
-            with self._tx():
-                self._conn.execute(
-                    "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, 0)"
-                )
-            current_version = 0
+            else:
+                # Existing DB with no version tracking — start from 0, apply all migrations.
+                with self._tx():
+                    self._conn.execute(
+                        "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, 0)"
+                    )
+                current_version = 0
         else:
             current_version = row[0]
 
@@ -245,14 +246,11 @@ class StateDB:
             for alias in aliases:
                 alias = alias.strip()
                 if alias and alias.lower() != name.lower():
-                    try:
-                        self._conn.execute(
-                            "INSERT OR IGNORE INTO concept_aliases"
-                            " (concept_name, alias) VALUES (?, ?)",
-                            (name, alias),
-                        )
-                    except Exception:
-                        pass
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO concept_aliases"
+                        " (concept_name, alias) VALUES (?, ?)",
+                        (name, alias),
+                    )
         self._conn.commit()
 
     def close(self) -> None:
@@ -385,7 +383,7 @@ class StateDB:
                 )
 
     def get_aliases(self, concept_name: str) -> list[str]:
-        """All aliases stored for a concept (case-sensitive match on concept_name)."""
+        """All aliases stored for a concept (case-insensitive match on concept_name)."""
         rows = self._conn.execute(
             "SELECT alias FROM concept_aliases WHERE lower(concept_name) = lower(?) ORDER BY alias",
             (concept_name,),

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -247,8 +247,7 @@ class StateDB:
                 alias = alias.strip()
                 if alias and alias.lower() != name.lower():
                     self._conn.execute(
-                        "INSERT OR IGNORE INTO concept_aliases"
-                        " (concept_name, alias) VALUES (?, ?)",
+                        "INSERT OR IGNORE INTO concept_aliases (concept_name, alias) VALUES (?, ?)",
                         (name, alias),
                     )
         self._conn.commit()

--- a/src/obsidian_llm_wiki/state.py
+++ b/src/obsidian_llm_wiki/state.py
@@ -8,6 +8,7 @@ Schema versioning: schema_version table tracks migration level.
   v1 — initial (summary/quality columns on raw_notes)
   v2 — rejections, stubs, blocked_concepts tables; approved_at/approval_notes on wiki_articles
   v3 — language column on raw_notes
+  v4 — concept_aliases table; backfill from existing concept titles
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from pathlib import Path
 
 from .models import RawNoteRecord, WikiArticleRecord
 
-_CURRENT_SCHEMA_VERSION = 3
+_CURRENT_SCHEMA_VERSION = 4
 
 # Full current schema — idempotent (CREATE IF NOT EXISTS).
 # Fresh DBs get all tables + columns from here. Existing DBs use _VERSIONED_MIGRATIONS.
@@ -79,10 +80,17 @@ CREATE TABLE IF NOT EXISTS blocked_concepts (
     blocked_at TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS concept_aliases (
+    concept_name TEXT NOT NULL,
+    alias        TEXT NOT NULL,
+    PRIMARY KEY (concept_name, alias)
+);
+
 CREATE INDEX IF NOT EXISTS idx_raw_hash ON raw_notes(content_hash);
 CREATE INDEX IF NOT EXISTS idx_raw_status ON raw_notes(status);
 CREATE INDEX IF NOT EXISTS idx_concept_name ON concepts(name);
 CREATE INDEX IF NOT EXISTS idx_rejections_concept ON rejections(concept);
+CREATE INDEX IF NOT EXISTS idx_alias_lookup ON concept_aliases(lower(alias));
 """
 
 # Migrations keyed by version they bring the DB to.
@@ -116,6 +124,14 @@ _VERSIONED_MIGRATIONS: dict[int, list[str]] = {
     ],
     3: [
         "ALTER TABLE raw_notes ADD COLUMN language TEXT",
+    ],
+    4: [
+        """CREATE TABLE IF NOT EXISTS concept_aliases (
+               concept_name TEXT NOT NULL,
+               alias        TEXT NOT NULL,
+               PRIMARY KEY (concept_name, alias)
+           )""",
+        "CREATE INDEX IF NOT EXISTS idx_alias_lookup ON concept_aliases(lower(alias))",
     ],
 }
 
@@ -169,12 +185,13 @@ class StateDB:
                 r[1] for r in self._conn.execute("PRAGMA table_info(raw_notes)").fetchall()
             }
             if "approved_at" in wiki_cols and "language" in note_cols:
+                # DB has v3 features but no version record — stamp as v3 so the v4
+                # migration (backfill) still runs through the loop below.
                 with self._tx():
                     self._conn.execute(
-                        "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, ?)",
-                        (_CURRENT_SCHEMA_VERSION,),
+                        "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, 3)"
                     )
-                return
+                current_version = 3
             # Existing DB with no version tracking — start from 0, apply all migrations.
             with self._tx():
                 self._conn.execute(
@@ -196,12 +213,47 @@ class StateDB:
                 except sqlite3.OperationalError as e:
                     if "duplicate column" not in str(e).lower():
                         raise
+            if version == 4:
+                self._backfill_aliases_v4()
             with self._tx():
                 self._conn.execute(
                     "INSERT OR REPLACE INTO schema_version (id, version) VALUES (1, ?)",
                     (version,),
                 )
             current_version = version
+
+    def _backfill_aliases_v4(self) -> None:
+        """Populate concept_aliases with deterministic aliases for all existing concepts.
+
+        Uses the same logic as vault.generate_aliases: add lowercase variant + ALL_CAPS
+        abbreviations from parenthetical notation (e.g. 'Program Counter (PC)' → 'PC').
+        No LLM calls — fast and deterministic.
+        """
+        import re as _re
+
+        abbr_pattern = _re.compile(r"\(([A-Z]{2,})\)")
+        rows = self._conn.execute("SELECT DISTINCT name FROM concepts").fetchall()
+        for (name,) in rows:
+            aliases: list[str] = []
+            lower = name.lower()
+            if lower != name:
+                aliases.append(lower)
+            for m in abbr_pattern.finditer(name):
+                abbr = m.group(1)
+                if abbr.lower() != name.lower():
+                    aliases.append(abbr)
+            for alias in aliases:
+                alias = alias.strip()
+                if alias and alias.lower() != name.lower():
+                    try:
+                        self._conn.execute(
+                            "INSERT OR IGNORE INTO concept_aliases"
+                            " (concept_name, alias) VALUES (?, ?)",
+                            (name, alias),
+                        )
+                    except Exception:
+                        pass
+        self._conn.commit()
 
     def close(self) -> None:
         self._conn.close()
@@ -318,6 +370,60 @@ class StateDB:
             (name,),
         ).fetchall()
         return [r[0] for r in rows]
+
+    def upsert_aliases(self, concept_name: str, aliases: list[str]) -> None:
+        """Merge aliases for a concept. Skips self-matches (alias == canonical)."""
+        canonical_lower = concept_name.lower()
+        with self._tx():
+            for alias in aliases:
+                alias = alias.strip()
+                if not alias or alias.lower() == canonical_lower:
+                    continue
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO concept_aliases (concept_name, alias) VALUES (?, ?)",
+                    (concept_name, alias),
+                )
+
+    def get_aliases(self, concept_name: str) -> list[str]:
+        """All aliases stored for a concept (case-sensitive match on concept_name)."""
+        rows = self._conn.execute(
+            "SELECT alias FROM concept_aliases WHERE lower(concept_name) = lower(?) ORDER BY alias",
+            (concept_name,),
+        ).fetchall()
+        return [r[0] for r in rows]
+
+    def resolve_alias(self, surface: str) -> str | None:
+        """Return canonical concept name if surface unambiguously matches exactly one concept."""
+        rows = self._conn.execute(
+            "SELECT DISTINCT concept_name FROM concept_aliases WHERE lower(alias) = lower(?)",
+            (surface,),
+        ).fetchall()
+        if len(rows) == 1:
+            return rows[0][0]
+        return None
+
+    def list_alias_map(self) -> dict[str, str]:
+        """Return {lower(alias): canonical_name} for all unambiguous aliases.
+
+        Aliases claimed by more than one concept are excluded — they are unsafe to rewrite.
+        """
+        rows = self._conn.execute(
+            "SELECT lower(alias) as al, concept_name FROM concept_aliases"
+        ).fetchall()
+        counts: dict[str, int] = {}
+        mapping: dict[str, str] = {}
+        for al, canonical in rows:
+            counts[al] = counts.get(al, 0) + 1
+            mapping[al] = canonical
+        return {al: canonical for al, canonical in mapping.items() if counts[al] == 1}
+
+    def delete_aliases_for_concept(self, concept_name: str) -> None:
+        """Remove all aliases for a concept (call when concept is removed)."""
+        with self._tx():
+            self._conn.execute(
+                "DELETE FROM concept_aliases WHERE lower(concept_name) = lower(?)",
+                (concept_name,),
+            )
 
     def get_concepts_for_sources(self, source_paths: list[str]) -> list[str]:
         """Concept names linked to any of the given source paths."""

--- a/src/obsidian_llm_wiki/vault.py
+++ b/src/obsidian_llm_wiki/vault.py
@@ -248,6 +248,7 @@ def build_wiki_frontmatter(
     confidence: float,
     is_draft: bool = True,
     existing_meta: dict | None = None,
+    aliases: list[str] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now().strftime("%Y-%m-%d")
     meta: dict[str, Any] = {
@@ -258,8 +259,47 @@ def build_wiki_frontmatter(
         "status": "draft" if is_draft else "published",
         "updated": now,
     }
+    if aliases:
+        meta["aliases"] = aliases
     if existing_meta and "created" in existing_meta:
         meta["created"] = existing_meta["created"]
     else:
         meta["created"] = now
     return meta
+
+
+_WIKILINK_FULL_RE = re.compile(r"\[\[([^\]|#]+?)(?:#([^\]|]*))?(?:\|([^\]]*))?\]\]")
+
+
+def normalize_wikilinks(body: str, alias_map: dict[str, str], known_titles: set[str]) -> str:
+    """Rewrite [[Alias]] → [[Canonical|Alias]] for unambiguous aliases.
+
+    - If target is already a canonical title: leave unchanged.
+    - If target matches an unambiguous alias: rewrite target to canonical, preserve display.
+    - If ambiguous or unknown: leave unchanged (lint will flag).
+    - Fragments (#) and display text (|) are preserved.
+    - Code blocks are protected from rewrites.
+    """
+    masked, spans = _mask_code_blocks(body)
+
+    def _rewrite(m: re.Match) -> str:
+        target = m.group(1).strip()
+        fragment = m.group(2)  # may be None
+        display = m.group(3)  # may be None
+
+        # Already a known canonical title → leave unchanged
+        if target.lower() in {t.lower() for t in known_titles}:
+            return m.group(0)
+
+        # Try alias map
+        canonical = alias_map.get(target.lower())
+        if canonical is None:
+            return m.group(0)  # unknown / ambiguous
+
+        # Build rewritten link preserving display and fragment
+        effective_display = display if display is not None else target
+        frag_part = f"#{fragment}" if fragment else ""
+        return f"[[{canonical}{frag_part}|{effective_display}]]"
+
+    rewritten = _WIKILINK_FULL_RE.sub(_rewrite, masked)
+    return _restore_code_blocks(rewritten, spans)

--- a/src/obsidian_llm_wiki/vault.py
+++ b/src/obsidian_llm_wiki/vault.py
@@ -281,6 +281,7 @@ def normalize_wikilinks(body: str, alias_map: dict[str, str], known_titles: set[
     - Code blocks are protected from rewrites.
     """
     masked, spans = _mask_code_blocks(body)
+    known_lower = {t.lower() for t in known_titles}
 
     def _rewrite(m: re.Match) -> str:
         target = m.group(1).strip()
@@ -288,7 +289,7 @@ def normalize_wikilinks(body: str, alias_map: dict[str, str], known_titles: set[
         display = m.group(3)  # may be None
 
         # Already a known canonical title → leave unchanged
-        if target.lower() in {t.lower() for t in known_titles}:
+        if target.lower() in known_lower:
             return m.group(0)
 
         # Try alias map

--- a/tests/fixtures/analysis_valid.json
+++ b/tests/fixtures/analysis_valid.json
@@ -1,6 +1,11 @@
 {
   "summary": "This note covers quantum entanglement and its applications in quantum computing.",
-  "key_concepts": ["quantum entanglement", "quantum computing", "superposition", "Bell states"],
+  "concepts": [
+    {"name": "quantum entanglement", "aliases": ["entanglement", "QE"]},
+    {"name": "quantum computing", "aliases": ["QC"]},
+    {"name": "superposition", "aliases": []},
+    {"name": "Bell states", "aliases": []}
+  ],
   "suggested_topics": ["Quantum Entanglement", "Quantum Computing Basics"],
   "quality": "high"
 }

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -56,7 +56,7 @@ def _analysis_json(n_concepts: int = 4) -> str:
     return json.dumps(
         {
             "summary": "A concise two-sentence summary of the note content.",
-            "key_concepts": [f"Concept {i}" for i in range(n_concepts)],
+            "concepts": [{"name": f"Concept {i}", "aliases": []} for i in range(n_concepts)],
             "suggested_topics": ["Topic A", "Topic B"],
             "quality": "high",
         }
@@ -70,9 +70,11 @@ def _mock_client(n_concepts: int = 4) -> MagicMock:
 
 
 def _make_result(n: int = 4) -> AnalysisResult:
+    from obsidian_llm_wiki.models import Concept
+
     return AnalysisResult(
         summary="Summary.",
-        key_concepts=[f"Concept {i}" for i in range(n)],
+        concepts=[Concept(name=f"Concept {i}", aliases=[]) for i in range(n)],
         suggested_topics=["Topic"],
         quality="high",
     )

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -15,7 +15,7 @@ from obsidian_llm_wiki.pipeline.ingest import (
     _analyze_body,
     _build_analysis_prompt,
     _merge_chunk_results,
-    _normalize_concept_names,
+    _normalize_concepts,
     _preprocess_web_clip,
     ingest_note,
 )
@@ -159,36 +159,44 @@ def test_build_prompt_no_chunk_label_by_default():
     assert "[part" not in prompt
 
 
-# ── _normalize_concept_names ──────────────────────────────────────────────────
+# ── _normalize_concepts ───────────────────────────────────────────────────────
+
+
+def _make_concepts(names):
+    from obsidian_llm_wiki.models import Concept
+
+    return [Concept(name=n, aliases=[]) for n in names]
 
 
 def test_normalize_reuses_canonical_case(vault, config, db):
     db.upsert_concepts("raw/a.md", ["Quantum Computing"])
-    result = _normalize_concept_names(["quantum computing"], db)
-    assert result == ["Quantum Computing"]  # canonical form preserved
+    result = _normalize_concepts(_make_concepts(["quantum computing"]), db)
+    assert [name for name, _ in result] == ["Quantum Computing"]
 
 
 def test_normalize_deduplicates(vault, config, db):
-    result = _normalize_concept_names(["ML", "ML", "Machine Learning"], db)
+    result = _normalize_concepts(_make_concepts(["ML", "ML", "Machine Learning"]), db)
     assert len(result) == 2
-    assert "ML" in result
+    assert any(name == "ML" for name, _ in result)
 
 
 def test_normalize_strips_empty(vault, config, db):
-    result = _normalize_concept_names(["", "  ", "Neural Networks"], db)
-    assert "" not in result
-    assert "  " not in result
-    assert "Neural Networks" in result
+    result = _normalize_concepts(_make_concepts(["", "  ", "Neural Networks"]), db)
+    names = [name for name, _ in result]
+    assert "" not in names
+    assert "  " not in names
+    assert "Neural Networks" in names
 
 
 # ── ingest_note ───────────────────────────────────────────────────────────────
 
 
 def _analysis_json(concepts=None, quality="high", summary="A summary."):
+    names = concepts or ["Quantum Computing", "Qubit"]
     return json.dumps(
         {
             "summary": summary,
-            "key_concepts": concepts or ["Quantum Computing", "Qubit"],
+            "concepts": [{"name": c, "aliases": []} for c in names],
             "suggested_topics": ["Quantum Computing"],
             "quality": quality,
         }
@@ -201,7 +209,7 @@ def test_ingest_note_returns_analysis_result(vault, config, db):
     result = ingest_note(path, config, client, db)
     assert result is not None
     assert result.quality == "high"
-    assert len(result.key_concepts) >= 1
+    assert len(result.concepts) >= 1
 
 
 def test_ingest_note_stores_status_ingested(vault, config, db):
@@ -361,9 +369,11 @@ def test_ingest_note_respects_max_concepts_per_source(vault, config, db):
 
 
 def _make_result(concepts, summary="Summary.", quality="high", topics=None):
+    from obsidian_llm_wiki.models import Concept
+
     return AnalysisResult(
         summary=summary,
-        key_concepts=concepts,
+        concepts=[Concept(name=c, aliases=[]) for c in concepts],
         suggested_topics=topics or ["Topic"],
         quality=quality,
     )
@@ -378,14 +388,14 @@ def test_merge_unions_concepts():
     r1 = _make_result(["A", "B"])
     r2 = _make_result(["B", "C"])
     merged = _merge_chunk_results([r1, r2])
-    assert merged.key_concepts == ["A", "B", "C"]  # B deduped
+    assert [c.name for c in merged.concepts] == ["A", "B", "C"]  # B deduped
 
 
 def test_merge_concept_dedup_case_insensitive():
     r1 = _make_result(["Machine Learning"])
     r2 = _make_result(["machine learning", "Deep Learning"])
     merged = _merge_chunk_results([r1, r2])
-    names_lower = [c.lower() for c in merged.key_concepts]
+    names_lower = [c.name.lower() for c in merged.concepts]
     assert names_lower.count("machine learning") == 1
     assert "deep learning" in names_lower
 
@@ -473,7 +483,7 @@ def test_analysis_result_stores_language_in_db(vault, config, db):
     analysis = json.dumps(
         {
             "summary": "A French note.",
-            "key_concepts": ["Bonjour"],
+            "concepts": [{"name": "Bonjour", "aliases": []}],
             "suggested_topics": ["Salutations"],
             "quality": "high",
             "language": "fr",
@@ -489,7 +499,7 @@ def test_analysis_result_language_none_stored(vault, config, db):
     analysis = json.dumps(
         {
             "summary": "Unknown language note.",
-            "key_concepts": ["Mixed"],
+            "concepts": [{"name": "Mixed", "aliases": []}],
             "suggested_topics": [],
             "quality": "medium",
             "language": None,
@@ -502,7 +512,7 @@ def test_analysis_result_language_none_stored(vault, config, db):
 
 def test_merge_chunk_results_picks_first_detected_language():
     make = lambda lang: AnalysisResult(  # noqa: E731
-        summary="s", key_concepts=[], suggested_topics=[], quality="high", language=lang
+        summary="s", concepts=[], suggested_topics=[], quality="high", language=lang
     )
     merged = _merge_chunk_results([make(None), make("de"), make("fr")])
     assert merged.language == "de"

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -12,11 +12,12 @@ from obsidian_llm_wiki.models import RawNoteRecord
 from obsidian_llm_wiki.pipeline.maintain import (
     _extract_link_target,
     create_stubs,
+    normalize_published_alias_links,
     suggest_concept_merges,
     suggest_orphan_links,
 )
 from obsidian_llm_wiki.state import StateDB
-from obsidian_llm_wiki.vault import atomic_write
+from obsidian_llm_wiki.vault import atomic_write, parse_note
 
 
 @pytest.fixture
@@ -173,6 +174,25 @@ def test_create_stubs_stub_body_has_info_callout(config, db):
     assert "[!info]" in content or "stub" in content.lower()
 
 
+def test_create_stubs_strips_md_extension(config, db):
+    """Model sometimes emits [[raw-note.md]] wikilinks; stub name must not be 'raw-note.md'."""
+    from obsidian_llm_wiki.models import LintIssue
+
+    issues = [
+        LintIssue(
+            path="wiki/Article.md",
+            issue_type="broken_link",
+            description="[[deep-learning.md]] not found",
+            suggestion="",
+        )
+    ]
+    created = create_stubs(config, db, broken_link_issues=issues)
+    assert len(created) == 1
+    # Stub file must NOT have double .md extension
+    assert not created[0].name.endswith(".md.md"), f"double extension: {created[0].name}"
+    assert created[0].name == "deep-learning.md"
+
+
 def test_create_stubs_empty_issues(config, db):
     created = create_stubs(config, db, broken_link_issues=[])
     assert created == []
@@ -183,6 +203,60 @@ def test_create_stubs_none_runs_lint_internally(config, db):
     # Empty wiki → lint finds no broken links → no stubs created
     created = create_stubs(config, db, broken_link_issues=None)
     assert created == []
+
+
+# ── normalize_published_alias_links ──────────────────────────────────────────
+
+
+def test_normalize_published_alias_links_rewrites_alias(config, db):
+    canonical = "Program Counter"
+    _write_article(config, canonical, "## Body\n\nHolds the next instruction address.")
+    db.upsert_aliases(canonical, ["PC"])
+
+    # Write a second article that uses the alias form
+    other = config.wiki_dir / "Other Article.md"
+    post = fm_lib.Post(
+        "[[PC]] is important.", title="Other Article", status="published", tags=[], sources=[]
+    )
+    atomic_write(other, fm_lib.dumps(post))
+
+    modified = normalize_published_alias_links(config, db)
+    assert modified >= 1
+
+    _, body = parse_note(other)
+    assert "[[Program Counter|PC]]" in body
+
+
+def test_normalize_published_alias_links_skips_canonical(config, db):
+    canonical = "Program Counter"
+    art = _write_article(config, canonical, "## Body\n\nContent.")
+    db.upsert_aliases(canonical, ["PC"])
+
+    _, body_before = parse_note(art)
+    normalize_published_alias_links(config, db)
+    _, body_after = parse_note(art)
+    assert body_before == body_after
+
+
+def test_normalize_published_alias_links_dry_run(config, db):
+    _write_article(config, "Arithmetic Logic Unit", "## Body\n\nContent.")
+    db.upsert_aliases("Arithmetic Logic Unit", ["ALU"])
+
+    other = config.wiki_dir / "Ref.md"
+    post = fm_lib.Post(
+        "See [[ALU]] for details.", title="Ref", status="published", tags=[], sources=[]
+    )
+    atomic_write(other, fm_lib.dumps(post))
+
+    modified = normalize_published_alias_links(config, db, dry_run=True)
+    assert modified >= 1
+    _, body = parse_note(other)
+    assert "[[ALU]]" in body  # not rewritten in dry-run
+
+
+def test_normalize_published_alias_links_empty_alias_map(config, db):
+    _write_article(config, "Concept", "## Body\n\nContent.")
+    assert normalize_published_alias_links(config, db) == 0
 
 
 # ── suggest_orphan_links ──────────────────────────────────────────────────────

--- a/tests/test_pipeline_language.py
+++ b/tests/test_pipeline_language.py
@@ -44,7 +44,7 @@ def test_ingest_detects_and_stores_language(vault, config, db):
     analysis = json.dumps(
         {
             "summary": "A French note.",
-            "key_concepts": ["Bonjour"],
+            "concepts": [{"name": "Bonjour", "aliases": []}],
             "suggested_topics": ["Salutations"],
             "quality": "high",
             "language": "fr",

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -38,7 +38,7 @@ def test_valid_analysis_json(fixtures_dir):
         model="gemma4:e4b",
     )
     assert result.quality == "high"
-    assert "quantum entanglement" in result.key_concepts
+    assert any(c.name == "quantum entanglement" for c in result.concepts)
     assert len(result.suggested_topics) > 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.3.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Implements issues #27 (alias backfill), #28 (alias-aware page resolution), #29 (alias link normalization) plus smoke test hardening.

New:
- Maintain: normalize_published_alias_links rewrites [[alias]] to [[Canonical|alias]] across published articles
- Query: _find_page falls back to alias table when canonical lookup misses
- State: aliases table with content-hash tracked backfill on migration
- CLI: status --failed filter, maintain --fix stub/alias/merge paths

Smoke test (scripts/smoke_test.sh) three-tier hardening:
- Tier 1: tightened fake-pass checks (lint health score, lint --fix exit code, aliases hard assertion, ~12 sites split exit-code from output grep)
- Tier 2: lint issue-type coverage — inline_tag, missing_frontmatter, invalid_tag, low_confidence, stale
- Tier 3: maintain --fix idempotency, stub shape assertions, compile --legacy bit-rot guard, status --failed filter coverage
