### PR TITLE
fix: coerce string concepts to Concept objects in AnalysisResult

### DIFF
--- a/src/obsidian_llm_wiki/models.py
+++ b/src/obsidian_llm_wiki/models.py
@@ -47,6 +47,13 @@ class AnalysisResult(BaseModel):
         description="ISO 639-1 language code of the note (e.g. 'en', 'fr', 'de'). Null if uncertain.",  # noqa: E501
     )
 
+    @field_validator("concepts", mode="before")
+    @classmethod
+    def coerce_concepts(cls, v: Any) -> list[Any]:
+        if not isinstance(v, list):
+            return v
+        return [{"name": item, "aliases": []} if isinstance(item, str) else item for item in v]
+
 
 class ArticlePlan(BaseModel):
     """Single entry in a CompilePlan — no content, just the roadmap."""


### PR DESCRIPTION
## Problem

Some LLMs (particularly smaller local models) return `concepts` as a flat list of strings rather than the expected list of `{"name": ..., "aliases": [...]}` objects. This causes a Pydantic `model_type` validation error at ingest time:

```
Input should be a valid dictionary or instance of Concept
  [type=model_type, input_value='금융 도메인 (Finance Domain)', input_type=str]
```

## Fix

Add a `field_validator("concepts", mode="before")` to `AnalysisResult` that coerces plain strings to `{"name": item, "aliases": []}` dicts before Pydantic validates them. This is consistent with the existing `clean_tags` pattern already used on `SingleArticle`.

```python
@field_validator("concepts", mode="before")
@classmethod
def coerce_concepts(cls, v: Any) -> list[Any]:
    if not isinstance(v, list):
        return v
    return [{"name": item, "aliases": []} if isinstance(item, str) else item for item in v]
```

No aliases are lost — the LLM didn't provide them in the first place when returning strings. The three-tier retry logic in `structured_output.py` can still kick in on subsequent attempts if needed, but this validator makes the pipeline resilient to this common model quirk instead of failing hard.

## Test plan

- [ ] Confirm `AnalysisResult(concepts=["Foo", "Bar"], ...)` no longer raises a validation error
- [ ] Confirm `AnalysisResult(concepts=[{"name": "Foo", "aliases": ["f"]}], ...)` still works as before