### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.5.1] - 2026-04-19
+
+### Highlights
+
+**v0.5.1 hardens the pipeline against a common quirk of small local models.** When the fast model returns `concepts` as a flat list of strings instead of `{name, aliases}` objects, ingest no longer fails — the payload is coerced transparently and the note proceeds. The root cause, an over-literal JSON template passed to the model, is also fixed so every `list[Model]` field benefits from the same resilience.
+
+### Bug Fixes
+
+- **String-concept tolerance (#32)** — `AnalysisResult` accepts a flat list of concept strings from the LLM and wraps them into `Concept` objects with empty aliases. Mixed payloads (some strings, some dicts) also validate. A `log.debug` line fires when coercion triggers, so the signal stays observable for prompt-tuning.
+- **Structured-output template renders nested objects** — the fill-in JSON example passed to the fast model now expands `list[Concept]`, `list[ArticlePlan]`, and `list[LintIssue]` into their real shape, including enum discriminator values. Previously the model saw only the array's description string and sometimes produced wrong item types. `Optional[...]` fields still carry their outer description through `anyOf`.
+
+### Changes
+
+- **Cleaner error when the vault path is missing** — `olw <cmd>` now prints a short, actionable message pointing at `olw init` or `olw setup` instead of surfacing a raw config-loading traceback.
+- **Smoke test**: new pre-LLM "Structured output resilience" block pins the validator + template + `request_structured` end-to-end against a stub client, so the class of failure above is caught in the installed artifact without requiring a running model.
+- README: concept-block rejection / `olw unblock` section trimmed and clarified.
+
 ## [0.5.0] - 2026-04-18
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -549,17 +549,10 @@ olw init ~/my-wiki
 
 **Q: A concept keeps getting rejected — how do I stop it from recompiling?**
 
-After 5 rejections the concept is auto-blocked and excluded from future compiles. If it blocks earlier than you'd like:
+After 5 rejections with feedback (`olw reject --feedback "…"`), the concept is auto-blocked and excluded from future compiles. `olw status` lists blocked concepts. To re-enable one:
 
 ```bash
-olw unblock "Concept Name"   # re-enable
-```
-
-Or manually block it:
-
-```bash
-# Mark as blocked so compile skips it
-olw status   # shows blocked concepts
+olw unblock "Concept Name"
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-llm-wiki"
-version = "0.5.0"
+version = "0.5.1"
 description = "Convert Obsidian notes into an AI-maintained wiki using local or cloud LLMs"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -147,7 +147,7 @@ export OLW_VAULT="$VAULT_DIR"
 #   4. request_structured end-to-end handles a string-concept LLM response
 header "Structured output resilience"
 
-_SO_SCRIPT=$(mktemp /tmp/olw_so_smoke.XXXXXX.py)
+_SO_SCRIPT=$(mktemp /tmp/olw_so_smoke.XXXXXX)
 cat > "$_SO_SCRIPT" <<'PYEOF'
 import json
 from unittest.mock import MagicMock

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -138,6 +138,72 @@ pass "uv sync"
 OLW="uv run --project $REPO_DIR olw"
 export OLW_VAULT="$VAULT_DIR"
 
+# ── Structured output resilience (PR #32 + _make_template recursion) ──────────
+# Pure-Python regression guard — runs without any LLM. Verifies:
+#   1. AnalysisResult.coerce_concepts wraps list[str] → list[Concept] (PR #32)
+#   2. Mixed list[str | dict] still validates
+#   3. _make_template renders list[Concept] as nested object example, not the
+#      array description string (root cause behind PR #32)
+#   4. request_structured end-to-end handles a string-concept LLM response
+header "Structured output resilience"
+
+_SO_SCRIPT=$(mktemp /tmp/olw_so_smoke.XXXXXX.py)
+cat > "$_SO_SCRIPT" <<'PYEOF'
+import json
+from unittest.mock import MagicMock
+
+from obsidian_llm_wiki.models import AnalysisResult
+from obsidian_llm_wiki.structured_output import _make_template, request_structured
+
+r = AnalysisResult(
+    summary="s",
+    concepts=["Foo", "Bar"],
+    suggested_topics=[],
+    quality="high",
+    language=None,
+)
+assert [c.name for c in r.concepts] == ["Foo", "Bar"]
+assert all(c.aliases == [] for c in r.concepts)
+
+r = AnalysisResult(
+    summary="s",
+    concepts=[{"name": "A", "aliases": ["a"]}, "B"],
+    suggested_topics=[],
+    quality="high",
+    language=None,
+)
+assert r.concepts[0].aliases == ["a"]
+assert r.concepts[1].name == "B" and r.concepts[1].aliases == []
+
+tpl = json.loads(_make_template(AnalysisResult))
+assert isinstance(tpl["concepts"][0], dict), tpl["concepts"]
+assert set(tpl["concepts"][0]) == {"name", "aliases"}
+
+fake = json.dumps({
+    "summary": "s",
+    "concepts": ["Alpha", "Beta"],
+    "suggested_topics": [],
+    "quality": "high",
+})
+client = MagicMock()
+client.generate.return_value = fake
+parsed = request_structured(
+    client=client,
+    prompt="x",
+    model_class=AnalysisResult,
+    model="fake",
+    max_retries=0,
+)
+assert [c.name for c in parsed.concepts] == ["Alpha", "Beta"]
+print("ok")
+PYEOF
+
+_SO_OUT=$(uv run --project "$REPO_DIR" python "$_SO_SCRIPT" 2>&1); _SO_RC=$?
+rm -f "$_SO_SCRIPT"
+if [[ $_SO_RC -ne 0 ]]; then echo "$_SO_OUT"; fi
+check "string-concept list coerced end-to-end (PR #32 + template fix)" \
+    "test $_SO_RC -eq 0"
+
 # ── Init ──────────────────────────────────────────────────────────────────────
 header "olw init"
 

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -64,6 +64,14 @@ def _load_config(vault_str: str | None, **kwargs):
             err=True,
         )
         sys.exit(1)
+    if not vault_path.is_dir():
+        click.echo(
+            f"Error: vault path is not a directory: {vault_path}\n"
+            "A vault is a directory containing wiki.toml. "
+            "Point --vault / OLW_VAULT at the parent directory instead.",
+            err=True,
+        )
+        sys.exit(1)
     return Config.from_vault(vault_path, **kwargs)
 
 

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -55,7 +55,16 @@ def _load_config(vault_str: str | None, **kwargs):
             err=True,
         )
         sys.exit(1)
-    return Config.from_vault(Path(vault_str), **kwargs)
+    vault_path = Path(vault_str).expanduser().resolve()
+    if not vault_path.exists():
+        click.echo(
+            f"Error: vault path does not exist: {vault_path}\n"
+            f"Run `olw init {vault_path}` to create it, or re-run `olw setup` "
+            f"to update the default vault.",
+            err=True,
+        )
+        sys.exit(1)
+    return Config.from_vault(vault_path, **kwargs)
 
 
 def _load_db(config):

--- a/src/obsidian_llm_wiki/models.py
+++ b/src/obsidian_llm_wiki/models.py
@@ -8,12 +8,15 @@ reliably produce valid JSON for them.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from .sanitize import sanitize_tags
+
+log = logging.getLogger(__name__)
 
 # ── LLM Output Models (keep schemas small and flat) ──────────────────────────
 
@@ -52,6 +55,9 @@ class AnalysisResult(BaseModel):
     def coerce_concepts(cls, v: Any) -> list[Any]:
         if not isinstance(v, list):
             return v
+        n_coerced = sum(1 for item in v if isinstance(item, str))
+        if n_coerced:
+            log.debug("coerced %d/%d bare-string concepts to Concept objects", n_coerced, len(v))
         return [{"name": item, "aliases": []} if isinstance(item, str) else item for item in v]
 
 

--- a/src/obsidian_llm_wiki/structured_output.py
+++ b/src/obsidian_llm_wiki/structured_output.py
@@ -47,7 +47,8 @@ class StructuredOutputError(Exception):
 def _resolve_ref(node: dict, defs: dict) -> dict:
     if "$ref" in node:
         key = node["$ref"].rsplit("/", 1)[-1]
-        return defs.get(key, {})
+        resolved = defs.get(key)
+        return resolved if isinstance(resolved, dict) else node
     return node
 
 

--- a/src/obsidian_llm_wiki/structured_output.py
+++ b/src/obsidian_llm_wiki/structured_output.py
@@ -44,28 +44,59 @@ class StructuredOutputError(Exception):
     pass
 
 
+def _resolve_ref(node: dict, defs: dict) -> dict:
+    if "$ref" in node:
+        key = node["$ref"].rsplit("/", 1)[-1]
+        return defs.get(key, {})
+    return node
+
+
+def _render_example(node: dict, defs: dict, field_name: str = "") -> object:
+    """Render a schema node as a fill-in JSON example value."""
+    node = _resolve_ref(node, defs)
+
+    if "anyOf" in node and "type" not in node:
+        outer_desc = node.get("description", "")
+        for alt in node["anyOf"]:
+            if alt.get("type") != "null":
+                if outer_desc and "description" not in alt:
+                    alt = {**alt, "description": outer_desc}
+                return _render_example(alt, defs, field_name)
+        return None
+
+    ftype = node.get("type")
+    desc = node.get("description", "")
+    enum = node.get("enum")
+
+    if enum:
+        return " | ".join(str(e) for e in enum)
+    if ftype == "array":
+        items = _resolve_ref(node.get("items", {}), defs)
+        if items.get("type") == "object" or "properties" in items:
+            return [_render_example(items, defs, field_name)]
+        return [desc[:60] or f"<{field_name} item>"]
+    if ftype == "object" or "properties" in node:
+        return {
+            sub_name: _render_example(sub, defs, sub_name)
+            for sub_name, sub in node.get("properties", {}).items()
+        }
+    if ftype in ("integer", "number"):
+        return 0
+    if ftype == "boolean":
+        return True
+    return desc[:80] or f"<{field_name}>"
+
+
 def _make_template(model_class: type[T]) -> str:
-    """Build a fill-in JSON example from model fields (simpler than raw JSON Schema)."""
+    """Build a fill-in JSON example from model fields (simpler than raw JSON Schema).
+
+    Recursively expands nested objects so small models see the real structure
+    for fields typed as `list[NestedModel]` instead of the array description.
+    """
     schema = model_class.model_json_schema()
+    defs = schema.get("$defs", {}) or schema.get("definitions", {})
     props = schema.get("properties", {})
-
-    template: dict = {}
-    for field_name, field_schema in props.items():
-        ftype = field_schema.get("type", "string")
-        desc = field_schema.get("description", "")
-        enum = field_schema.get("enum")
-
-        if enum:
-            template[field_name] = " | ".join(str(e) for e in enum)
-        elif ftype == "array":
-            template[field_name] = [desc[:60] or f"<{field_name} item>"]
-        elif ftype in ("integer", "number"):
-            template[field_name] = 0
-        elif ftype == "boolean":
-            template[field_name] = True
-        else:
-            template[field_name] = desc[:80] or f"<{field_name}>"
-
+    template = {name: _render_example(sub, defs, name) for name, sub in props.items()}
     return json.dumps(template, indent=2)
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from obsidian_llm_wiki.config import Config
-from obsidian_llm_wiki.models import AnalysisResult
+from obsidian_llm_wiki.models import AnalysisResult, Concept
 from obsidian_llm_wiki.pipeline.ingest import (
     _SYSTEM,
     _analyze_body,
@@ -516,3 +516,30 @@ def test_merge_chunk_results_picks_first_detected_language():
     )
     merged = _merge_chunk_results([make(None), make("de"), make("fr")])
     assert merged.language == "de"
+
+
+# ── AnalysisResult.coerce_concepts ────────────────────────────────────────────
+
+
+def test_analysis_result_coerces_string_concepts():
+    r = AnalysisResult(
+        summary="s",
+        concepts=["Foo", "Bar"],
+        suggested_topics=[],
+        quality="high",
+        language=None,
+    )
+    assert r.concepts == [Concept(name="Foo", aliases=[]), Concept(name="Bar", aliases=[])]
+
+
+def test_analysis_result_accepts_mixed_concepts():
+    r = AnalysisResult(
+        summary="s",
+        concepts=[{"name": "A", "aliases": ["a"]}, "B"],
+        suggested_topics=[],
+        quality="high",
+        language=None,
+    )
+    assert r.concepts[0].aliases == ["a"]
+    assert r.concepts[1].name == "B"
+    assert r.concepts[1].aliases == []

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -246,7 +246,7 @@ def test_template_expands_compile_plan_articles():
     articles = template["articles"]
     assert isinstance(articles[0], dict)
     assert {"title", "action", "path", "reasoning", "source_paths"} <= set(articles[0].keys())
-    assert articles[0]["action"] == "create | update"
+    assert set(articles[0]["action"].split(" | ")) == {"create", "update"}
 
 
 def test_template_expands_lint_issues_with_enum():

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -11,9 +11,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from obsidian_llm_wiki.models import AnalysisResult, CompilePlan, SingleArticle
+from obsidian_llm_wiki.models import AnalysisResult, CompilePlan, LintResult, SingleArticle
 from obsidian_llm_wiki.ollama_client import OllamaClient
-from obsidian_llm_wiki.structured_output import StructuredOutputError, request_structured
+from obsidian_llm_wiki.structured_output import (
+    StructuredOutputError,
+    _make_template,
+    request_structured,
+)
 
 
 def _client(response: str) -> OllamaClient:
@@ -221,3 +225,47 @@ def test_single_article_missing_required_field():
             model="qwen2.5:14b",
             max_retries=0,
         )
+
+
+# ── _make_template: nested object rendering ──────────────────────────────────
+
+
+def test_template_expands_nested_object_array():
+    """AnalysisResult.concepts is list[Concept] — template must show the object shape,
+    not the array's description string."""
+    template = json.loads(_make_template(AnalysisResult))
+    concepts = template["concepts"]
+    assert isinstance(concepts, list) and len(concepts) == 1
+    assert isinstance(concepts[0], dict)
+    assert set(concepts[0].keys()) == {"name", "aliases"}
+    assert isinstance(concepts[0]["aliases"], list)
+
+
+def test_template_expands_compile_plan_articles():
+    template = json.loads(_make_template(CompilePlan))
+    articles = template["articles"]
+    assert isinstance(articles[0], dict)
+    assert {"title", "action", "path", "reasoning", "source_paths"} <= set(articles[0].keys())
+    assert articles[0]["action"] == "create | update"
+
+
+def test_template_expands_lint_issues_with_enum():
+    template = json.loads(_make_template(LintResult))
+    issue = template["issues"][0]
+    assert isinstance(issue, dict)
+    assert "orphan" in issue["issue_type"]
+    assert issue["auto_fixable"] is True
+
+
+def test_template_primitive_array_keeps_description_hint():
+    """list[str] still rendered as legacy single-string hint (not object)."""
+    template = json.loads(_make_template(AnalysisResult))
+    assert template["suggested_topics"] == [
+        "Titles of wiki articles this note should feed into (max 5)"
+    ]
+
+
+def test_template_optional_field_keeps_outer_description():
+    """Optional[str] (anyOf[str, null]) must still carry the parent field description."""
+    template = json.loads(_make_template(AnalysisResult))
+    assert "ISO 639-1" in template["language"]

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release hardening the pipeline against small-model concept output quirks and tightening the ingest UX around missing vault paths.

Fixes:
- AnalysisResult.coerce_concepts wraps list[str] concepts into Concept objects with empty aliases (follow-up to #32). Mixed payloads also validate. Emits log.debug when coercion fires.
- structured_output._make_template recursively expands nested array items ($ref + anyOf), so list[Concept], list[ArticlePlan], and list[LintIssue] render with real object shape + enum discriminators in the prompt template. Removes the upstream cause behind #32. Optional[str] fields still inherit their outer description through anyOf so language hints aren't lost.
- cli._load_config errors cleanly with an olw init / olw setup hint when the configured vault path does not exist.

Tests:
- 5 new regression tests (2 in test_ingest.py covering coerce_concepts, 3 in test_structured_output.py covering template nested-object rendering, primitive-array hint preservation, and Optional anyOf description propagation).
- scripts/smoke_test.sh: new pre-LLM "Structured output resilience" block pins the validator + template + request_structured end-to-end against a stub client. No LLM dependency.