### PR TITLE
Release v0.8.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Three-stage local LLM pipeline turning Obsidian raw notes into a synthesized wik
 - **Config loading order:** `--vault` flag → `OLW_VAULT` env var → global config default vault → error
 - **Git safety:** All auto-operations use `[olw]`-prefixed commits; undo uses `git revert` (never destructive)
 - **Error handling:** LLM failures log + mark note as "failed" + continue (no crash). Config loading returns None on failure (fail open)
+- **Code comments:** Add comments only when the reason or invariant is non-obvious from the code itself. Prefer tests and commit messages for routine explanation; use comments for safeguards, provider quirks, heuristics, and tradeoffs that future agents or humans could otherwise misread.
 - **Testing:** All 200 tests mock OllamaClient via MagicMock, use tmp_path vaults and in-memory SQLite. Fixtures in `tests/fixtures/`. Integration tests marked with `@pytest.mark.integration`
 - **Python 3.11+:** Uses `tomllib` (stdlib), `from __future__ import annotations`, full type hints
 - **Ruff config:** rules E, F, I, UP; line-length 100

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -1396,13 +1396,7 @@ def status(vault_str, show_failed):
 
     pid = lock_holder_pid(config.vault)
     if pid is not None:
-        import os
-
-        try:
-            os.kill(pid, 0)
-            console.print(f"\n[yellow]⚠ Pipeline lock held by PID {pid}[/yellow]")
-        except (ProcessLookupError, PermissionError):
-            console.print(f"\n[dim]Lock file present (PID {pid}) but process not running[/dim]")
+        console.print(f"\n[yellow]⚠ Pipeline lock held by PID {pid}[/yellow]")
     elif has_invalid_lock_file(config.vault):
         console.print("\n[dim]Lock file present but invalid; no live process holds it[/dim]")
 

--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -1850,6 +1850,8 @@ def run(
         console.print(f"\n[yellow]{len(report.failed)} concept(s) failed:[/yellow]")
         for f in report.failed:
             console.print(f"  [dim]{f.concept}[/dim] ({f.reason.value})")
+            if f.error_msg:
+                console.print(f"    [dim]{f.error_msg}[/dim]")
 
 
 # ── review ────────────────────────────────────────────────────────────────────

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -76,6 +76,8 @@ def default_wiki_toml(
         f"ingest_parallel = false   # true = parallel chunks\n"
         f"article_max_tokens = 16384 # soft cap on generated tokens per article; "
         f"auto-reduced to fit context\n"
+        f"concept_draft_soft_cap = 1800 # concept-driven compile only; set to "
+        f'"article_max_tokens" to disable extra capping (no effect on --legacy)\n'
         f"{citation_line}"
         f'# source_citation_style = "legend-only"  # legend-only | inline-wikilink\n'
         f'# draft_media = "reference"  # reference | embed | omit\n'
@@ -116,6 +118,7 @@ class PipelineConfig(BaseModel):
     auto_maintain: bool = False
     ingest_parallel: bool = False  # parallel chunk analysis (needs OLLAMA_NUM_PARALLEL≥4)
     article_max_tokens: int = 16384
+    concept_draft_soft_cap: int | str = 1800
     inline_source_citations: bool = False
     source_citation_style: str = "legend-only"
     draft_media: str = "reference"
@@ -129,6 +132,21 @@ class PipelineConfig(BaseModel):
             raise ValueError(
                 f"article_max_tokens must be >= 512 (got {value}); "
                 "values below this disable structured generation reliability."
+            )
+        return value
+
+    @field_validator("concept_draft_soft_cap")
+    @classmethod
+    def validate_concept_draft_soft_cap(cls, value: int | str) -> int | str:
+        if isinstance(value, str):
+            if value != "article_max_tokens":
+                raise ValueError(
+                    'concept_draft_soft_cap must be an integer >= 512 or "article_max_tokens"'
+                )
+            return value
+        if value < 512:
+            raise ValueError(
+                f"concept_draft_soft_cap must be >= 512 (got {value}) when set numerically"
             )
         return value
 

--- a/src/obsidian_llm_wiki/config.py
+++ b/src/obsidian_llm_wiki/config.py
@@ -76,7 +76,7 @@ def default_wiki_toml(
         f"ingest_parallel = false   # true = parallel chunks\n"
         f"article_max_tokens = 16384 # soft cap on generated tokens per article; "
         f"auto-reduced to fit context\n"
-        f"concept_draft_soft_cap = 1800 # concept-driven compile only; set to "
+        f"concept_draft_soft_cap = 2400 # concept-driven compile only; set to "
         f'"article_max_tokens" to disable extra capping (no effect on --legacy)\n'
         f"{citation_line}"
         f'# source_citation_style = "legend-only"  # legend-only | inline-wikilink\n'
@@ -118,7 +118,7 @@ class PipelineConfig(BaseModel):
     auto_maintain: bool = False
     ingest_parallel: bool = False  # parallel chunk analysis (needs OLLAMA_NUM_PARALLEL≥4)
     article_max_tokens: int = 16384
-    concept_draft_soft_cap: int | str = 1800
+    concept_draft_soft_cap: int | str = 2400
     inline_source_citations: bool = False
     source_citation_style: str = "legend-only"
     draft_media: str = "reference"

--- a/src/obsidian_llm_wiki/openai_compat_client.py
+++ b/src/obsidian_llm_wiki/openai_compat_client.py
@@ -65,7 +65,7 @@ class LLMTruncatedError(LLMError):
         self.completion_tokens = completion_tokens
         self.finish_reason = finish_reason
 
-        if max_tokens > 0:
+        if finish_reason in ("length", "max_tokens") and max_tokens > 0:
             suggested = max(max_tokens * 2, 32768)
             detail = (
                 f"output truncated at max_tokens={max_tokens} "
@@ -82,9 +82,11 @@ class LLMTruncatedError(LLMError):
             )
         else:
             detail = (
-                f"model returned empty response (finish_reason={finish_reason or 'unknown'}). "
-                "Likely causes: model context exhausted, response_format rejected silently, "
-                "or model/prompt incompatibility. Check model logs."
+                f"model returned no usable content (finish_reason={finish_reason or 'unknown'}). "
+                "Likely causes: model context exhausted, provider/model incompatibility, or "
+                "an excessively large requested output budget. Check that heavy_ctx matches "
+                "the loaded model context, consider lowering pipeline.article_max_tokens, and "
+                "check model logs."
             )
         super().__init__(f"{provider}: {detail}")
 

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -15,6 +15,7 @@ Articles are written to wiki/.drafts/ for human review before publishing.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 import time
@@ -104,12 +105,6 @@ def _resolve_language(sources: list[str], db: StateDB, config: Config) -> str | 
     return langs.pop() if len(langs) == 1 else None
 
 
-# Token budget constants
-_BUDGET_SYSTEM = 600  # system + schema
-_BUDGET_TOPIC_LIST = 400  # existing article titles
-_BUDGET_OUTPUT = 1800  # room for generated content
-_BUDGET_SAFETY = 200  # buffer
-
 _QUALITY_BONUS = {"high": 0.25, "medium": 0.1, "low": 0.0}
 
 # Stubs are short by design (≤150 words). Hardcoded cap is intentional.
@@ -118,6 +113,8 @@ _MAX_STUB_PREDICT = 512
 # Math floor: structured generation needs enough headroom for title + content + tags.
 # Below this, JSON schema can't reliably complete.
 _MIN_ARTICLE_PREDICT = 512
+
+_STRUCTURED_ERROR_VERSION = 1
 
 
 def _content_hash(text: str) -> str:
@@ -133,6 +130,28 @@ def _categorize_failure(exc: Exception) -> str:
     if isinstance(exc, StructuredOutputError):
         return "structured_output"
     return "other"
+
+
+def _structured_compile_error(reason: str, message: str) -> str:
+    return json.dumps(
+        {"version": _STRUCTURED_ERROR_VERSION, "reason": reason, "message": message},
+        ensure_ascii=True,
+    )
+
+
+def _concept_draft_num_predict(config: Config, prompt: str, system: str) -> int:
+    computed = _article_num_predict(config, prompt, system)
+    soft_cap = config.pipeline.concept_draft_soft_cap
+    if soft_cap == "article_max_tokens":
+        return computed
+    capped = min(soft_cap, computed)
+    if computed > capped:
+        log.info(
+            "Capping concept draft output budget %d -> %d (pipeline.concept_draft_soft_cap)",
+            computed,
+            capped,
+        )
+    return capped
 
 
 def _article_num_predict(config: Config, prompt: str, system: str) -> int:
@@ -885,8 +904,14 @@ def compile_concepts(
                 )
             except (StructuredOutputError, LLMBadRequestError, LLMTruncatedError) as e:
                 log.error("Failed to write stub '%s': %s", name, e)
-                _record_failure(name, _categorize_failure(e))
-                db.mark_concept_compile_state(name, source_paths, "failed", error=str(e))
+                reason = _categorize_failure(e)
+                _record_failure(name, reason)
+                db.mark_concept_compile_state(
+                    name,
+                    source_paths,
+                    "failed",
+                    error=_structured_compile_error(reason, str(e)),
+                )
                 continue
             draft_path = _write_draft(
                 content_result=result,
@@ -937,30 +962,34 @@ def compile_concepts(
         if not resolved_paths:
             log.warning("No readable sources for concept '%s', skipping", name)
             _record_failure(name, "no_sources")
-            db.mark_concept_compile_state(name, source_paths, "failed", error="No readable sources")
+            db.mark_concept_compile_state(
+                name,
+                source_paths,
+                "failed",
+                error=_structured_compile_error("no_sources", "No readable sources"),
+            )
             continue
 
         try:
-            # Concept drafts stay on a fixed soft output budget even when heavy_ctx or
-            # article_max_tokens is huge; without this, OpenAI-compatible backends can be
-            # asked for absurd outputs and fail in misleading ways.
-            num_predict = min(
-                _BUDGET_OUTPUT,
-                _article_num_predict(
-                    config,
-                    write_prompt,
-                    (
-                        _WRITE_SYSTEM_WITH_CITATIONS
-                        if config.pipeline.inline_source_citations
-                        else _WRITE_SYSTEM
-                    ),
+            # Concept drafts stay on a configurable soft output budget so users can
+            # keep the default safety rail or explicitly opt back into article_max_tokens.
+            num_predict = _concept_draft_num_predict(
+                config,
+                write_prompt,
+                (
+                    _WRITE_SYSTEM_WITH_CITATIONS
+                    if config.pipeline.inline_source_citations
+                    else _WRITE_SYSTEM
                 ),
             )
         except ValueError as e:
             log.error("Failed to write '%s': %s", name, e)
             _record_failure(name, "context_too_large")
             db.mark_concept_compile_state(
-                name, resolved_paths or source_paths, "failed", error=str(e)
+                name,
+                resolved_paths or source_paths,
+                "failed",
+                error=_structured_compile_error("context_too_large", str(e)),
             )
             continue
 
@@ -1027,16 +1056,13 @@ def compile_concepts(
                         inline_source_citations=config.pipeline.inline_source_citations,
                     )
                     try:
-                        fallback_num_predict = min(
-                            _BUDGET_OUTPUT,
-                            _article_num_predict(
-                                config,
-                                fallback_prompt,
-                                (
-                                    _WRITE_SYSTEM_WITH_CITATIONS
-                                    if config.pipeline.inline_source_citations
-                                    else _WRITE_SYSTEM
-                                ),
+                        fallback_num_predict = _concept_draft_num_predict(
+                            config,
+                            fallback_prompt,
+                            (
+                                _WRITE_SYSTEM_WITH_CITATIONS
+                                if config.pipeline.inline_source_citations
+                                else _WRITE_SYSTEM
                             ),
                         )
                     except ValueError as retry_error:
@@ -1085,7 +1111,10 @@ def compile_concepts(
                 log.error("Failed to write '%s': %s", name, e)
                 _record_failure(name, failure_category)
                 db.mark_concept_compile_state(
-                    name, resolved_paths or source_paths, "failed", error=str(e)
+                    name,
+                    resolved_paths or source_paths,
+                    "failed",
+                    error=_structured_compile_error(failure_category, str(e)),
                 )
                 continue
 
@@ -1246,6 +1275,9 @@ def compile_notes(
         write_prompt = _write_prompt_legacy(article, sources_text, existing_titles, language=lang)
 
         try:
+            # Legacy compile intentionally follows only article_max_tokens plus remaining
+            # context budget. concept_draft_soft_cap applies to the default concept-driven
+            # path and does not change --legacy behavior.
             num_predict = _article_num_predict(config, write_prompt, _WRITE_SYSTEM)
         except ValueError as e:
             log.error("Failed to write '%s': %s", article.title, e)

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -150,6 +150,7 @@ def _article_num_predict(config: Config, prompt: str, system: str) -> int:
             f"prompt ~{estimated_prompt_tokens} tokens leaves only {available_output} "
             f"for output (need >= {_MIN_ARTICLE_PREDICT}). Reduce sources or raise heavy_ctx."
         )
+
     return max(_MIN_ARTICLE_PREDICT, min(config.pipeline.article_max_tokens, available_output))
 
 
@@ -940,13 +941,16 @@ def compile_concepts(
             continue
 
         try:
-            num_predict = _article_num_predict(
-                config,
-                write_prompt,
-                (
-                    _WRITE_SYSTEM_WITH_CITATIONS
-                    if config.pipeline.inline_source_citations
-                    else _WRITE_SYSTEM
+            num_predict = min(
+                _BUDGET_OUTPUT,
+                _article_num_predict(
+                    config,
+                    write_prompt,
+                    (
+                        _WRITE_SYSTEM_WITH_CITATIONS
+                        if config.pipeline.inline_source_citations
+                        else _WRITE_SYSTEM
+                    ),
                 ),
             )
         except ValueError as e:
@@ -1020,13 +1024,16 @@ def compile_concepts(
                         inline_source_citations=config.pipeline.inline_source_citations,
                     )
                     try:
-                        fallback_num_predict = _article_num_predict(
-                            config,
-                            fallback_prompt,
-                            (
-                                _WRITE_SYSTEM_WITH_CITATIONS
-                                if config.pipeline.inline_source_citations
-                                else _WRITE_SYSTEM
+                        fallback_num_predict = min(
+                            _BUDGET_OUTPUT,
+                            _article_num_predict(
+                                config,
+                                fallback_prompt,
+                                (
+                                    _WRITE_SYSTEM_WITH_CITATIONS
+                                    if config.pipeline.inline_source_citations
+                                    else _WRITE_SYSTEM
+                                ),
                             ),
                         )
                     except ValueError as retry_error:

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -941,6 +941,9 @@ def compile_concepts(
             continue
 
         try:
+            # Concept drafts stay on a fixed soft output budget even when heavy_ctx or
+            # article_max_tokens is huge; without this, OpenAI-compatible backends can be
+            # asked for absurd outputs and fail in misleading ways.
             num_predict = min(
                 _BUDGET_OUTPUT,
                 _article_num_predict(

--- a/src/obsidian_llm_wiki/pipeline/lint.py
+++ b/src/obsidian_llm_wiki/pipeline/lint.py
@@ -337,10 +337,17 @@ def _add_graph_quality_issues(
             )
         )
 
-    concept_targets = {
-        title.lower() for title, path in title_index.items() if ".drafts" in path.parts
-    }
+    concept_targets: set[str] = set()
     disconnected: list[Path] = []
+    if config.drafts_dir.exists():
+        draft_pages = sorted(config.drafts_dir.rglob("*.md"))
+        for draft in draft_pages:
+            try:
+                meta, _ = parse_note(draft)
+            except Exception:
+                continue
+            concept_targets.add(str(meta.get("title", draft.stem)).lower())
+
     if len(concept_targets) >= 2 and config.drafts_dir.exists():
         for draft in sorted(config.drafts_dir.rglob("*.md")):
             try:

--- a/src/obsidian_llm_wiki/pipeline/lint.py
+++ b/src/obsidian_llm_wiki/pipeline/lint.py
@@ -337,24 +337,19 @@ def _add_graph_quality_issues(
             )
         )
 
-    concept_targets: set[str] = set()
     disconnected: list[Path] = []
+    draft_data: list[tuple[Path, str, str]] = []
     if config.drafts_dir.exists():
-        draft_pages = sorted(config.drafts_dir.rglob("*.md"))
-        for draft in draft_pages:
-            try:
-                meta, _ = parse_note(draft)
-            except Exception:
-                continue
-            concept_targets.add(str(meta.get("title", draft.stem)).lower())
-
-    if len(concept_targets) >= 2 and config.drafts_dir.exists():
         for draft in sorted(config.drafts_dir.rglob("*.md")):
             try:
                 meta, body = parse_note(draft)
             except Exception:
                 continue
-            own_title = str(meta.get("title", draft.stem)).lower()
+            draft_data.append((draft, str(meta.get("title", draft.stem)).lower(), body))
+
+    concept_targets = {title for _, title, _ in draft_data}
+    if len(concept_targets) >= 2:
+        for draft, own_title, body in draft_data:
             concept_links = {
                 link.lower()
                 for link in extract_wikilinks(body)

--- a/src/obsidian_llm_wiki/pipeline/orchestrator.py
+++ b/src/obsidian_llm_wiki/pipeline/orchestrator.py
@@ -11,6 +11,7 @@ Used by `olw run` and `olw watch`. Handles:
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass, field
@@ -251,39 +252,66 @@ def _run_compile(
 
     # Classify individual concept failures from the persisted compile_state error.
     # compile_concepts already records per-concept failure details in the DB.
-    failure_records = [
-        FailureRecord(
-            concept=name,
-            reason=_classify_compile_failure(db, name),
-        )
-        for name in failed_names
-    ]
+    failure_records: list[FailureRecord] = []
+    for name in failed_names:
+        reason, error_msg = _classify_compile_failure(db, name)
+        failure_records.append(FailureRecord(concept=name, reason=reason, error_msg=error_msg))
     return draft_paths, failure_records, concept_timings
 
 
-def _classify_compile_failure(db: StateDB, concept_name: str) -> FailureReason:
+def _classify_compile_failure(db: StateDB, concept_name: str) -> tuple[FailureReason, str]:
     source_paths = db.get_sources_for_concept(concept_name)
     for source_path in source_paths:
         row = db.get_compile_state(concept_name, source_path)
         if row is None or row["status"] != "failed" or not row["error"]:
             continue
 
-        # compile_concepts persists only error text today, so preserve useful user-facing
-        # categories by decoding the stored message instead of collapsing everything to unknown.
-        message = str(row["error"]).lower()
-        if "output truncated" in message or "no usable content" in message:
-            return FailureReason.TRUNCATED
-        if "no readable sources" in message:
-            return FailureReason.MISSING_SOURCES
-        if (
-            "structured output" in message
-            or "json" in message
-            or "context too large" in message
-            or "heavy_ctx" in message
-            or "context length" in message
-            or "n_keep" in message
-            or "http 400" in message
-        ):
-            return FailureReason.LLM_OUTPUT
+        reason, message = _parse_compile_failure_payload(str(row["error"]))
+        if reason is not None:
+            return reason, message
 
-    return FailureReason.UNKNOWN
+        # Legacy fallback for older rows that persisted only plain-text messages.
+        lower = message.lower()
+        if "output truncated" in lower or "no usable content" in lower:
+            return FailureReason.TRUNCATED, message
+        if "no readable sources" in lower:
+            return FailureReason.MISSING_SOURCES, message
+        if (
+            "structured output" in lower
+            or "json schema" in lower
+            or "parse json" in lower
+            or "bad json" in lower
+            or "context too large" in lower
+            or "heavy_ctx" in lower
+            or "context length" in lower
+            or "n_keep" in lower
+            or "http 400" in lower
+        ):
+            return FailureReason.LLM_OUTPUT, message
+
+        return FailureReason.UNKNOWN, message
+
+    return FailureReason.UNKNOWN, ""
+
+
+def _parse_compile_failure_payload(payload: str) -> tuple[FailureReason | None, str]:
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        return None, payload
+
+    if not isinstance(data, dict):
+        return None, payload
+    message = str(data.get("message") or payload)
+    reason = data.get("reason")
+    mapping = {
+        "truncated": FailureReason.TRUNCATED,
+        "no_sources": FailureReason.MISSING_SOURCES,
+        "structured_output": FailureReason.LLM_OUTPUT,
+        "bad_request": FailureReason.LLM_OUTPUT,
+        "context_too_large": FailureReason.LLM_OUTPUT,
+        "other": FailureReason.UNKNOWN,
+    }
+    if isinstance(reason, str) and reason in mapping:
+        return mapping[reason], message
+    return None, message

--- a/src/obsidian_llm_wiki/pipeline/orchestrator.py
+++ b/src/obsidian_llm_wiki/pipeline/orchestrator.py
@@ -268,6 +268,8 @@ def _classify_compile_failure(db: StateDB, concept_name: str) -> FailureReason:
         if row is None or row["status"] != "failed" or not row["error"]:
             continue
 
+        # compile_concepts persists only error text today, so preserve useful user-facing
+        # categories by decoding the stored message instead of collapsing everything to unknown.
         message = str(row["error"]).lower()
         if "output truncated" in message or "no usable content" in message:
             return FailureReason.TRUNCATED

--- a/src/obsidian_llm_wiki/pipeline/orchestrator.py
+++ b/src/obsidian_llm_wiki/pipeline/orchestrator.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 
 class FailureReason(StrEnum):
     TRANSIENT = "transient"  # timeout, connection reset — retry
+    TRUNCATED = "truncated"  # model hit output cap or returned empty capped response
     LLM_OUTPUT = "llm_output"  # bad JSON / schema mismatch — structured_output already retried 3×
     MISSING_SOURCES = "missing_sources"  # no readable source files
     UNKNOWN = "unknown"
@@ -248,11 +249,39 @@ def _run_compile(
             {},
         )
 
-    # Classify individual concept failures
-    # compile_concepts returns bare names — we can't know the exact reason
-    # per-concept without changing its return type. Use UNKNOWN for now;
-    # transient failures (timeouts) will bubble up as LLMError above.
+    # Classify individual concept failures from the persisted compile_state error.
+    # compile_concepts already records per-concept failure details in the DB.
     failure_records = [
-        FailureRecord(concept=name, reason=FailureReason.UNKNOWN) for name in failed_names
+        FailureRecord(
+            concept=name,
+            reason=_classify_compile_failure(db, name),
+        )
+        for name in failed_names
     ]
     return draft_paths, failure_records, concept_timings
+
+
+def _classify_compile_failure(db: StateDB, concept_name: str) -> FailureReason:
+    source_paths = db.get_sources_for_concept(concept_name)
+    for source_path in source_paths:
+        row = db.get_compile_state(concept_name, source_path)
+        if row is None or row["status"] != "failed" or not row["error"]:
+            continue
+
+        message = str(row["error"]).lower()
+        if "output truncated" in message or "no usable content" in message:
+            return FailureReason.TRUNCATED
+        if "no readable sources" in message:
+            return FailureReason.MISSING_SOURCES
+        if (
+            "structured output" in message
+            or "json" in message
+            or "context too large" in message
+            or "heavy_ctx" in message
+            or "context length" in message
+            or "n_keep" in message
+            or "http 400" in message
+        ):
+            return FailureReason.LLM_OUTPUT
+
+    return FailureReason.UNKNOWN

--- a/src/obsidian_llm_wiki/vault.py
+++ b/src/obsidian_llm_wiki/vault.py
@@ -270,9 +270,14 @@ def build_wiki_frontmatter(
     aliases: list[str] | None = None,
 ) -> dict[str, Any]:
     now = datetime.now().strftime("%Y-%m-%d")
+    sanitized_tags = sanitize_tags(tags)
+    if not sanitized_tags and existing_meta and isinstance(existing_meta.get("tags"), list):
+        sanitized_tags = sanitize_tags(
+            [str(tag) for tag in existing_meta["tags"] if tag is not None]
+        )
     meta: dict[str, Any] = {
         "title": title,
-        "tags": sanitize_tags(tags),
+        "tags": sanitized_tags,
         "sources": sources,
         "confidence": round(confidence, 2),
         "status": "draft" if is_draft else "published",

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from obsidian_llm_wiki.cli import cli
+from obsidian_llm_wiki.config import Config
+from obsidian_llm_wiki.pipeline.lock import pipeline_lock
+from obsidian_llm_wiki.state import StateDB
+
+
+def _init_status_vault(tmp_path):
+    (tmp_path / "raw").mkdir()
+    (tmp_path / "wiki").mkdir()
+    (tmp_path / "wiki" / ".drafts").mkdir()
+    (tmp_path / "wiki" / "sources").mkdir()
+    (tmp_path / ".olw").mkdir()
+    (tmp_path / "wiki.toml").write_text(
+        """
+[models]
+fast = "test-fast"
+heavy = "test-heavy"
+
+[provider]
+name = "ollama"
+url = "http://localhost:11434"
+""".strip()
+    )
+    return Config(vault=tmp_path)
+
+
+def test_status_hides_released_lock_file(tmp_path):
+    _init_status_vault(tmp_path)
+    StateDB(tmp_path / ".olw" / "state.db")
+
+    with pipeline_lock(tmp_path) as acquired:
+        assert acquired is True
+
+    result = CliRunner().invoke(cli, ["status", "--vault", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Lock file present" not in result.output
+    assert "Pipeline lock held" not in result.output
+
+
+def test_status_shows_live_pipeline_lock(tmp_path):
+    _init_status_vault(tmp_path)
+    StateDB(tmp_path / ".olw" / "state.db")
+
+    with pipeline_lock(tmp_path) as acquired:
+        assert acquired is True
+        result = CliRunner().invoke(cli, ["status", "--vault", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "Pipeline lock held by PID" in result.output

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -46,6 +46,8 @@ def test_status_shows_live_pipeline_lock(tmp_path):
     _init_status_vault(tmp_path)
     StateDB(tmp_path / ".olw" / "state.db")
 
+    # CliRunner invokes the command in-process, so this assertion depends on POSIX flock
+    # treating a second open() on the same path as a contending live lock.
     with pipeline_lock(tmp_path) as acquired:
         assert acquired is True
         result = CliRunner().invoke(cli, ["status", "--vault", str(tmp_path)])

--- a/tests/test_compare_runner.py
+++ b/tests/test_compare_runner.py
@@ -10,7 +10,7 @@ import pytest
 
 from obsidian_llm_wiki.compare.runner import run_compare
 from obsidian_llm_wiki.config import Config
-from obsidian_llm_wiki.pipeline.orchestrator import PipelineReport
+from obsidian_llm_wiki.pipeline.orchestrator import FailureReason, FailureRecord, PipelineReport
 
 
 def _make_vault(tmp_path: Path) -> Path:
@@ -219,3 +219,62 @@ def test_run_compare_rejects_negative_sample_n(tmp_path, patched_pipeline):
 
     with pytest.raises(ValueError, match="sample_n must be at least 1"):
         run_compare(current, challenger, vault / ".olw" / "compare", sample_n=-1)
+
+
+def test_run_compare_serializes_failure_error_messages(tmp_path, monkeypatch):
+    vault = _make_vault(tmp_path)
+
+    fake_client = MagicMock()
+    fake_client.close = MagicMock()
+    monkeypatch.setattr("obsidian_llm_wiki.client_factory.build_client", lambda cfg: fake_client)
+
+    fake_db = MagicMock()
+    fake_db.close = MagicMock()
+    monkeypatch.setattr("obsidian_llm_wiki.state.StateDB", lambda _path: fake_db)
+
+    def fake_run(self, auto_approve=True, max_rounds=2):
+        return PipelineReport(
+            ingested=1,
+            compiled=0,
+            failed=[
+                FailureRecord(
+                    concept="Alpha",
+                    reason=FailureReason.TRUNCATED,
+                    error_msg="ollama: model returned no usable content",
+                )
+            ],
+            published=0,
+            lint_issues=0,
+            stubs_created=0,
+            rounds=1,
+            timings={"ingest": 1.0},
+            concept_timings={},
+        )
+
+    monkeypatch.setattr(
+        "obsidian_llm_wiki.pipeline.orchestrator.PipelineOrchestrator.run", fake_run
+    )
+
+    from obsidian_llm_wiki.pipeline.query import QueryRunResult
+
+    monkeypatch.setattr(
+        "obsidian_llm_wiki.pipeline.query.run_query",
+        lambda **_kw: QueryRunResult(answer="Answer.", selected_pages=["page1"]),
+    )
+
+    from obsidian_llm_wiki.models import LintResult
+
+    monkeypatch.setattr(
+        "obsidian_llm_wiki.pipeline.lint.run_lint",
+        lambda config, db, fix=False: LintResult(issues=[], health_score=95.0, summary="clean"),
+    )
+
+    current = Config.from_vault(vault)
+    challenger = Config.from_vault(vault, models={"heavy": "new-heavy"})
+    report = run_compare(current, challenger, vault / ".olw" / "compare")
+    root = vault / ".olw" / "compare" / report.run_id
+    raw_report = json.loads((root / "results" / "raw_report.json").read_text())
+
+    assert raw_report["current"]["pipeline_report"]["failed"][0]["error_msg"] == (
+        "ollama: model returned no usable content"
+    )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -137,6 +137,28 @@ def test_legacy_compile_uses_article_max_tokens_from_config(vault, config, db, f
     assert article_call.kwargs["num_predict"] == 12000
 
 
+def test_legacy_compile_ignores_concept_draft_soft_cap(vault, config, db, fixtures_dir):
+    """concept_draft_soft_cap applies only to concept-driven compile, not --legacy."""
+    config.pipeline.article_max_tokens = 5000
+    config.pipeline.concept_draft_soft_cap = 1200
+    config.provider = config.effective_provider.model_copy(update={"heavy_ctx": 32768})
+
+    raw_note = vault / "raw" / "note.md"
+    raw_note.write_text("# Note\n\nShort content.")
+    db.upsert_raw(RawNoteRecord(path="raw/note.md", content_hash="h", status="ingested"))
+
+    plan_json = (fixtures_dir / "compile_plan_valid.json").read_text()
+    article_json = (fixtures_dir / "single_article_valid.json").read_text()
+    client = _make_client(plan_json, article_json)
+
+    compile_notes(config=config, client=client, db=db)
+
+    write_calls = [c for c in client.generate.call_args_list if c.kwargs.get("num_predict")]
+    assert write_calls, "expected at least one generate call with num_predict"
+    article_call = write_calls[-1]
+    assert article_call.kwargs["num_predict"] == 5000
+
+
 def test_approve_moves_draft_to_wiki(vault, config, db):
     from obsidian_llm_wiki.models import WikiArticleRecord
     from obsidian_llm_wiki.vault import write_note

--- a/tests/test_compile_v2.py
+++ b/tests/test_compile_v2.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from obsidian_llm_wiki.config import Config
-from obsidian_llm_wiki.models import RawNoteRecord, WikiArticleRecord
+from obsidian_llm_wiki.models import RawNoteRecord, SingleArticle, WikiArticleRecord
 from obsidian_llm_wiki.ollama_client import OllamaClient
 from obsidian_llm_wiki.pipeline.compile import (
     _apply_draft_media_mode,
@@ -61,9 +61,37 @@ def make_mock_client(response: str = "{}") -> OllamaClient:
 
 
 def test_article_num_predict_respects_config_cap(config):
-    config.pipeline.article_max_tokens = 2048
+    config.pipeline.article_max_tokens = 1024
 
-    assert _article_num_predict(config, prompt="short", system="system") == 2048
+    assert _article_num_predict(config, prompt="short", system="system") == 1024
+
+
+def test_article_num_predict_concept_compile_applies_soft_output_cap(config, db, monkeypatch):
+    config.provider = config.effective_provider.model_copy(update={"heavy_ctx": 262144})
+    config.pipeline.article_max_tokens = 300000
+    db.upsert_raw(RawNoteRecord(path="raw/src.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/src.md", ["Heavy Concept"])
+    (config.vault / "raw" / "src.md").write_text(
+        "---\ntitle: Source\n---\nContent about Heavy Concept.",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, int] = {}
+
+    def fake_request_structured(**kwargs):
+        captured["num_predict"] = kwargs["num_predict"]
+        return SingleArticle(title="Heavy Concept", content="Body", tags=["heavy-concept"])
+
+    monkeypatch.setattr(
+        "obsidian_llm_wiki.pipeline.compile.request_structured",
+        fake_request_structured,
+    )
+
+    drafts, failed, _ = compile_concepts(config, make_mock_client(), db, concepts=["Heavy Concept"])
+
+    assert failed == []
+    assert len(drafts) == 1
+    assert captured["num_predict"] == 1800
 
 
 def test_article_num_predict_raises_when_context_too_small(config):

--- a/tests/test_compile_v2.py
+++ b/tests/test_compile_v2.py
@@ -91,7 +91,7 @@ def test_article_num_predict_concept_compile_applies_soft_output_cap(config, db,
 
     assert failed == []
     assert len(drafts) == 1
-    assert captured["num_predict"] == 1800
+    assert captured["num_predict"] == 2400
 
 
 def test_article_num_predict_concept_compile_can_disable_extra_soft_cap(config, db, monkeypatch):
@@ -632,6 +632,45 @@ def test_compile_concepts_preserves_canonical_title(config, db):
     assert len(drafts) == 1
     assert drafts[0].name == "Product Backlog.md"
     assert db.get_article("wiki/.drafts/Product Backlog.md").title == "Product Backlog"
+
+
+def test_compile_concepts_preserves_existing_tags_when_model_returns_none(config, db):
+    import hashlib
+    import json
+
+    db.upsert_raw(RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/a.md", ["Astrology"])
+    (config.vault / "raw" / "a.md").write_text("---\ntitle: A\n---\nContent.")
+    existing_body = "Existing."
+    existing_note = (
+        "---\n"
+        "title: Astrology\n"
+        "tags: [astrology, zodiac]\n"
+        "created: '2026-04-25'\n"
+        "---\n\n"
+        f"{existing_body}"
+    )
+    (config.wiki_dir / "Astrology.md").write_text(existing_note)
+    db.upsert_article(
+        WikiArticleRecord(
+            path="wiki/Astrology.md",
+            title="Astrology",
+            sources=["raw/a.md"],
+            content_hash=hashlib.sha256(existing_body.encode("utf-8")).hexdigest(),
+            is_draft=False,
+        )
+    )
+
+    client = make_mock_client(
+        json.dumps({"title": "Astrology", "content": "Updated content.", "tags": []})
+    )
+
+    drafts, failed, _ = compile_concepts(config, client, db, concepts=["Astrology"])
+
+    assert failed == []
+    assert len(drafts) == 1
+    draft_text = drafts[0].read_text(encoding="utf-8")
+    assert "tags:\n- astrology\n- zodiac" in draft_text
 
 
 def test_compile_concepts_legend_only_citations_do_not_link_inline(config, db):

--- a/tests/test_compile_v2.py
+++ b/tests/test_compile_v2.py
@@ -61,9 +61,9 @@ def make_mock_client(response: str = "{}") -> OllamaClient:
 
 
 def test_article_num_predict_respects_config_cap(config):
-    config.pipeline.article_max_tokens = 1024
+    config.pipeline.article_max_tokens = 2048
 
-    assert _article_num_predict(config, prompt="short", system="system") == 1024
+    assert _article_num_predict(config, prompt="short", system="system") == 2048
 
 
 def test_article_num_predict_concept_compile_applies_soft_output_cap(config, db, monkeypatch):
@@ -92,6 +92,35 @@ def test_article_num_predict_concept_compile_applies_soft_output_cap(config, db,
     assert failed == []
     assert len(drafts) == 1
     assert captured["num_predict"] == 1800
+
+
+def test_article_num_predict_concept_compile_can_disable_extra_soft_cap(config, db, monkeypatch):
+    config.provider = config.effective_provider.model_copy(update={"heavy_ctx": 262144})
+    config.pipeline.article_max_tokens = 5000
+    config.pipeline.concept_draft_soft_cap = "article_max_tokens"
+    db.upsert_raw(RawNoteRecord(path="raw/src.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/src.md", ["Heavy Concept"])
+    (config.vault / "raw" / "src.md").write_text(
+        "---\ntitle: Source\n---\nContent about Heavy Concept.",
+        encoding="utf-8",
+    )
+
+    captured: dict[str, int] = {}
+
+    def fake_request_structured(**kwargs):
+        captured["num_predict"] = kwargs["num_predict"]
+        return SingleArticle(title="Heavy Concept", content="Body", tags=["heavy-concept"])
+
+    monkeypatch.setattr(
+        "obsidian_llm_wiki.pipeline.compile.request_structured",
+        fake_request_structured,
+    )
+
+    drafts, failed, _ = compile_concepts(config, make_mock_client(), db, concepts=["Heavy Concept"])
+
+    assert failed == []
+    assert len(drafts) == 1
+    assert captured["num_predict"] == 5000
 
 
 def test_article_num_predict_raises_when_context_too_small(config):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,7 +37,7 @@ def test_pipeline_config_article_max_tokens_default():
 
 def test_pipeline_config_concept_draft_soft_cap_default():
     cfg = PipelineConfig()
-    assert cfg.concept_draft_soft_cap == 1800
+    assert cfg.concept_draft_soft_cap == 2400
 
 
 def test_pipeline_config_article_max_tokens_from_dict():
@@ -114,7 +114,7 @@ def test_default_wiki_toml_contains_inline_source_citations_comment():
 def test_default_wiki_toml_contains_graph_quality_defaults():
     toml = default_wiki_toml()
     assert "article_max_tokens = 16384" in toml
-    assert "concept_draft_soft_cap = 1800" in toml
+    assert "concept_draft_soft_cap = 2400" in toml
     assert "source_citation_style" in toml
     assert "draft_media" in toml
     assert "graph_quality_checks = true" in toml

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,9 +35,38 @@ def test_pipeline_config_article_max_tokens_default():
     assert cfg.article_max_tokens == 16384
 
 
+def test_pipeline_config_concept_draft_soft_cap_default():
+    cfg = PipelineConfig()
+    assert cfg.concept_draft_soft_cap == 1800
+
+
 def test_pipeline_config_article_max_tokens_from_dict():
     cfg = PipelineConfig(**{"article_max_tokens": 2048})
     assert cfg.article_max_tokens == 2048
+
+
+def test_pipeline_config_concept_draft_soft_cap_accepts_article_max_tokens_mode():
+    cfg = PipelineConfig(**{"concept_draft_soft_cap": "article_max_tokens"})
+    assert cfg.concept_draft_soft_cap == "article_max_tokens"
+
+
+def test_pipeline_config_concept_draft_soft_cap_validator_rejects_small_int():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="concept_draft_soft_cap must be >= 512"):
+        PipelineConfig(concept_draft_soft_cap=256)
+
+
+def test_pipeline_config_concept_draft_soft_cap_validator_rejects_unknown_string():
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(
+        ValidationError,
+        match='concept_draft_soft_cap must be an integer >= 512 or "article_max_tokens"',
+    ):
+        PipelineConfig(concept_draft_soft_cap="none")
 
 
 def test_pipeline_config_article_max_tokens_validator_rejects_below_floor():
@@ -85,6 +114,7 @@ def test_default_wiki_toml_contains_inline_source_citations_comment():
 def test_default_wiki_toml_contains_graph_quality_defaults():
     toml = default_wiki_toml()
     assert "article_max_tokens = 16384" in toml
+    assert "concept_draft_soft_cap = 1800" in toml
     assert "source_citation_style" in toml
     assert "draft_media" in toml
     assert "graph_quality_checks = true" in toml

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -427,6 +427,19 @@ def test_graph_quality_flags_low_concept_connectivity(vault, config, db):
     assert "and 1 more" in connectivity[0].description
 
 
+def test_graph_quality_ignores_draft_aliases_for_connectivity(vault, config, db):
+    write_note(
+        config.drafts_dir / "Alpha.md",
+        {"title": "Alpha", "aliases": ["Alias Alpha"], "tags": [], "status": "draft"},
+        "No links.",
+    )
+
+    result = run_lint(config, db)
+
+    connectivity = [i for i in result.issues if i.issue_type == "graph_connectivity"]
+    assert connectivity == []
+
+
 def test_graph_quality_checks_can_be_disabled(vault, config, db):
     config.pipeline.graph_quality_checks = False
     (config.vault / "Welcome.md").write_text("Welcome. [[create a link]]")

--- a/tests/test_openai_compat_client.py
+++ b/tests/test_openai_compat_client.py
@@ -163,3 +163,16 @@ def test_truncated_error_message_suggests_double():
     assert "article_max_tokens" in msg
     # suggested = max(cap*2, 32768) → 32768 here
     assert "32768" in msg
+
+
+def test_truncated_error_message_for_stop_does_not_suggest_raising_cap():
+    err = LLMTruncatedError(
+        provider="ollama",
+        max_tokens=251824,
+        finish_reason="stop",
+    )
+
+    msg = str(err)
+    assert "no usable content" in msg
+    assert "lowering pipeline.article_max_tokens" in msg
+    assert "Raise pipeline.article_max_tokens" not in msg

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -159,6 +159,73 @@ def test_run_compile_uses_persisted_truncated_reason(config, db):
     assert len(failures) == 1
     assert failures[0].reason == FailureReason.TRUNCATED
     assert failures[0].concept == "Fails"
+    assert "output truncated at max_tokens=251824" in failures[0].error_msg
+
+
+def test_run_compile_uses_persisted_no_usable_content_reason(config, db):
+    import obsidian_llm_wiki.pipeline.compile as compile_mod
+
+    db.upsert_raw(RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/a.md", ["Fails"])
+
+    original = compile_mod.compile_concepts
+
+    def fake_compile(**kwargs):
+        db.mark_concept_compile_state(
+            "Fails",
+            ["raw/a.md"],
+            "failed",
+            error=(
+                "ollama: model returned no usable content (finish_reason=stop). Likely causes: "
+                "model context exhausted, provider/model incompatibility, or an excessively "
+                "large requested output budget."
+            ),
+        )
+        return ([], ["Fails"], {})
+
+    compile_mod.compile_concepts = fake_compile
+    try:
+        drafts, failures, _ = _run_compile(
+            config, make_mock_client(), db, concepts=["Fails"], dry_run=False
+        )
+    finally:
+        compile_mod.compile_concepts = original
+
+    assert drafts == []
+    assert len(failures) == 1
+    assert failures[0].reason == FailureReason.TRUNCATED
+    assert "no usable content" in failures[0].error_msg
+
+
+def test_run_compile_reads_structured_failure_payload(config, db):
+    import obsidian_llm_wiki.pipeline.compile as compile_mod
+
+    db.upsert_raw(RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/a.md", ["Fails"])
+
+    original = compile_mod.compile_concepts
+
+    def fake_compile(**kwargs):
+        db.mark_concept_compile_state(
+            "Fails",
+            ["raw/a.md"],
+            "failed",
+            error=('{"version": 1, "reason": "no_sources", "message": "No readable sources"}'),
+        )
+        return ([], ["Fails"], {})
+
+    compile_mod.compile_concepts = fake_compile
+    try:
+        drafts, failures, _ = _run_compile(
+            config, make_mock_client(), db, concepts=["Fails"], dry_run=False
+        )
+    finally:
+        compile_mod.compile_concepts = original
+
+    assert drafts == []
+    assert len(failures) == 1
+    assert failures[0].reason == FailureReason.MISSING_SOURCES
+    assert failures[0].error_msg == "No readable sources"
 
 
 def test_run_compile_bad_request_not_transient(config, db):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -71,6 +71,7 @@ def test_pipeline_report_defaults():
 
 def test_failure_reason_values():
     assert FailureReason.TRANSIENT == "transient"
+    assert FailureReason.TRUNCATED == "truncated"
     assert FailureReason.LLM_OUTPUT == "llm_output"
     assert FailureReason.MISSING_SOURCES == "missing_sources"
     assert FailureReason.UNKNOWN == "unknown"
@@ -122,6 +123,41 @@ def test_run_compile_unknown_failure_per_concept(config, db):
 
     assert len(failures) == 1
     assert failures[0].reason == FailureReason.UNKNOWN
+    assert failures[0].concept == "Fails"
+
+
+def test_run_compile_uses_persisted_truncated_reason(config, db):
+    """Per-concept compile failures should preserve the persisted truncated category."""
+    import obsidian_llm_wiki.pipeline.compile as compile_mod
+
+    db.upsert_raw(RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/a.md", ["Fails"])
+
+    original = compile_mod.compile_concepts
+
+    def fake_compile(**kwargs):
+        db.mark_concept_compile_state(
+            "Fails",
+            ["raw/a.md"],
+            "failed",
+            error=(
+                "ollama: output truncated at max_tokens=251824 (finish_reason=stop). "
+                "Raise pipeline.article_max_tokens in your wiki.toml"
+            ),
+        )
+        return ([], ["Fails"], {})
+
+    compile_mod.compile_concepts = fake_compile
+    try:
+        drafts, failures, _ = _run_compile(
+            config, make_mock_client(), db, concepts=["Fails"], dry_run=False
+        )
+    finally:
+        compile_mod.compile_concepts = original
+
+    assert drafts == []
+    assert len(failures) == 1
+    assert failures[0].reason == FailureReason.TRUNCATED
     assert failures[0].concept == "Fails"
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -619,6 +619,24 @@ def test_list_failed_concepts_returns_distinct_names(db):
     assert db.list_failed_concepts() == ["Alpha", "Beta"]
 
 
+def test_mark_concept_compile_state_preserves_structured_error_payload(db):
+    import json
+
+    db.upsert_raw(RawNoteRecord(path="raw/a.md", content_hash="h1", status="ingested"))
+    db.upsert_concepts("raw/a.md", ["Alpha"])
+    payload = json.dumps({"version": 1, "reason": "truncated", "message": "Too long"})
+
+    db.mark_concept_compile_state("Alpha", ["raw/a.md"], "failed", error=payload)
+
+    row = db.get_compile_state("Alpha", "raw/a.md")
+    assert row is not None
+    assert json.loads(row["error"]) == {
+        "version": 1,
+        "reason": "truncated",
+        "message": "Too long",
+    }
+
+
 def test_ingest_chunk_crud(db):
     db.upsert_ingest_chunk(
         "raw/a.md",

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -337,6 +337,17 @@ def test_build_wiki_frontmatter_deduplicates_tags():
     assert meta["tags"] == ["ai", "machine-learning"]
 
 
+def test_build_wiki_frontmatter_preserves_existing_tags_when_new_tags_are_empty():
+    meta = build_wiki_frontmatter(
+        title="Test",
+        tags=[],
+        sources=[],
+        confidence=0.5,
+        existing_meta={"tags": ["astrology", "zodiac"]},
+    )
+    assert meta["tags"] == ["astrology", "zodiac"]
+
+
 def test_chunk_text_heading_split():
     text = (
         "# Title\n\nIntro paragraph.\n\n## Section 1\n\n"


### PR DESCRIPTION
## Summary
- fix concept compile failure reporting and stale status/lint regressions found in v0.8.1 follow-up validation
- raise the concept-driven draft soft cap to 2400 and preserve existing article tags when regeneration returns no tags
- add regression coverage for compile budgets, persisted failure details, status/lint behavior, and regeneration metadata

## Validation
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest -q
- real-vault reruns on disposable ~/my-wiki7 copies with LM Studio-backed full pipeline checks