### PR TITLE
fix: use fingerprint_concept for concept dedup instead of .lower()

### DIFF
--- a/src/obsidian_llm_wiki/pipeline/ingest.py
+++ b/src/obsidian_llm_wiki/pipeline/ingest.py
@@ -19,6 +19,7 @@ from ..models import AnalysisResult, Concept, RawNoteRecord
 from ..protocols import LLMClientProtocol
 from ..state import StateDB
 from ..structured_output import request_structured
+from ..text_utils import fingerprint_concept
 from ..vault import (
     chunk_text,
     generate_aliases,
@@ -76,26 +77,34 @@ def _merge_chunk_results(results: list[AnalysisResult]) -> AnalysisResult:
     if len(results) == 1:
         return results[0]
 
-    # Dedup concepts by canonical name (case-insensitive), merge aliases
-    seen: dict[str, list[str]] = {}  # lower(name) -> accumulated aliases
-    order: list[str] = []  # canonical names in insertion order
-    canonical_by_lower: dict[str, str] = {}
+    # Dedup concepts within a single note across chunks: normalize by
+    # lowercasing, stripping brackets, separators (_-/:), punctuation,
+    # and all whitespace.
+    # Catches format variants like "machine learning" vs "machine-learning"
+    # vs "machine_learning" that simple .lower() misses.
+    seen: dict[str, list[str]] = {}  # fingerprint(name) -> accumulated aliases
+    order: list[str] = []  # fingerprints in insertion order
+    canonical_by_fingerprint: dict[str, str] = {}
 
     for r in results:
         for c in r.concepts:
-            key = c.name.lower()
+            key = fingerprint_concept(c.name)
             if key not in seen:
                 seen[key] = list(c.aliases)
                 order.append(key)
-                canonical_by_lower[key] = c.name
+                canonical_by_fingerprint[key] = c.name
             else:
-                existing_lower = {a.lower() for a in seen[key]}
+                existing_fingerprints = {fingerprint_concept(a) for a in seen[key]}
                 for a in c.aliases:
-                    if a.lower() not in existing_lower:
+                    fp = fingerprint_concept(a)
+                    if fp not in existing_fingerprints:
                         seen[key].append(a)
-                        existing_lower.add(a.lower())
+                        existing_fingerprints.add(fp)
 
-    all_concepts = [Concept(name=canonical_by_lower[k], aliases=seen[k]) for k in order][:8]
+    all_concepts = [
+        Concept(name=canonical_by_fingerprint[k], aliases=seen[k])
+        for k in order
+    ][:8]
 
     seen_topics: set[str] = set()
     all_topics: list[str] = []

--- a/src/obsidian_llm_wiki/text_utils.py
+++ b/src/obsidian_llm_wiki/text_utils.py
@@ -1,0 +1,77 @@
+"""
+Text processing utilities.
+
+Provides concept normalization functions used across multiple modules.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+def normalize_concept(name: str, level: int = 3) -> str:
+    """
+    Concept normalization pipeline.
+
+    Levels control normalization strength:
+    - 1: Case folding
+    - 2: + Punctuation stripping
+    - 3: + Character normalization (for display/storage)
+    - 4: + Whitespace folding (for comparison/fingerprint only)
+    """
+    text = name.strip()
+
+    # Level 1: Case folding
+    text = text.lower()
+
+    if level >= 2:
+        # Level 2: Punctuation stripping
+        text = re.sub(r"[_\-/:]+", " ", text)
+
+    if level >= 3:
+        # Level 3: Character normalization
+        text = re.sub(r"\(.*?\)", "", text)
+        text = re.sub(r"[^\w\s]+", "", text)
+
+    if level >= 4:
+        # Level 4: Whitespace folding (fingerprint)
+        text = re.sub(r"\s+", "", text)
+
+    return text.strip()
+
+
+def canonicalize_concept(name: str) -> str:
+    """
+    Canonicalize concept name for display/storage (level 3).
+
+    Preserves readability while removing formatting variations.
+    """
+    return normalize_concept(name, level=3)
+
+
+def fingerprint_concept(name: str) -> str:
+    """
+    Generate concept fingerprint for dedup comparison (level 4).
+
+    Maximizes match rate by removing all whitespace and special characters.
+    """
+    return normalize_concept(name, level=4)
+
+
+def hash_concepts(concepts: list[str]) -> str:
+    """
+    Generate a hash for a group of concepts.
+
+    Used to uniquely identify dedup groups for skip tracking.
+    Sorts concepts first to ensure consistent hashing regardless of order.
+
+    Args:
+        concepts: List of concept names.
+
+    Returns:
+        SHA256 hash of the sorted, joined concept names.
+    """
+    sorted_concepts = sorted(c.lower().strip() for c in concepts)
+    key = "|".join(sorted_concepts)
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -681,6 +681,60 @@ def test_merge_concept_dedup_case_insensitive():
     assert "deep learning" in names_lower
 
 
+def test_merge_concept_dedup_whitespace_variants():
+    """Fingerprint dedup catches format variants that .lower() misses."""
+    r1 = _make_result(["machine learning"])
+    r2 = _make_result(["machine-learning", "machine_learning"])
+    merged = _merge_chunk_results([r1, r2])
+    assert len(merged.concepts) == 1
+    assert merged.concepts[0].name.lower() == "machine learning"
+
+
+def test_merge_concept_dedup_bracket_variants():
+    """Fingerprint dedup normalizes bracketed names to base form."""
+    r1 = _make_result(["Kubernetes (k8s)"])
+    r2 = _make_result(["kubernetes"])
+    merged = _merge_chunk_results([r1, r2])
+    assert len(merged.concepts) == 1
+
+
+def test_merge_concept_dedup_separator_variants():
+    """Fingerprint dedup treats hyphens, underscores, slashes as equivalent."""
+    r1 = _make_result(["API-Gateway"])
+    r2 = _make_result(["api_gateway"])
+    r3 = _make_result(["api/gateway"])
+    r4 = _make_result(["api gateway"])
+    merged = _merge_chunk_results([r1, r2, r3, r4])
+    assert len(merged.concepts) == 1
+
+
+def test_merge_concept_dedup_merges_aliases_across_chunks():
+    """Aliases from matching concepts are merged, with fingerprint dedup."""
+    c1 = [Concept(name="Machine Learning", aliases=["ML", "machine learning variant"])]
+    c2 = [Concept(name="machine learning", aliases=["statistical learning", "ML"])]
+    r1 = AnalysisResult(
+        summary="s", concepts=c1, suggested_topics=[], quality="high", language=None
+    )
+    r2 = AnalysisResult(
+        summary="s2", concepts=c2, suggested_topics=[], quality="high", language=None
+    )
+    merged = _merge_chunk_results([r1, r2])
+    assert len(merged.concepts) == 1
+    aliases_lower = {a.lower() for a in merged.concepts[0].aliases}
+    assert "ml" in aliases_lower
+    assert "machine learning variant" in aliases_lower
+    assert "statistical learning" in aliases_lower
+
+
+def test_merge_concepts_capped_at_8():
+    """After dedup, concepts list should be capped at 8."""
+    concepts = [f"Concept {i}" for i in range(15)]
+    r1 = _make_result(concepts[:10])
+    r2 = _make_result(concepts[5:])
+    merged = _merge_chunk_results([r1, r2])
+    assert len(merged.concepts) == 8
+
+
 def test_merge_summary_from_first_chunk():
     r1 = _make_result(["A"], summary="First summary.")
     r2 = _make_result(["B"], summary="Second summary.")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,82 @@
+"""Tests for text_utils.py."""
+
+from __future__ import annotations
+
+from obsidian_llm_wiki.text_utils import (
+    canonicalize_concept,
+    fingerprint_concept,
+    hash_concepts,
+    normalize_concept,
+)
+
+
+class TestNormalizeConcept:
+    def test_level_1_case_folding(self):
+        assert normalize_concept("Machine Learning", level=1) == "machine learning"
+
+    def test_level_2_strips_separators(self):
+        assert normalize_concept("machine-learning", level=2) == "machine learning"
+        assert normalize_concept("machine_learning", level=2) == "machine learning"
+        assert normalize_concept("api/gateway", level=2) == "api gateway"
+
+    def test_level_3_removes_brackets(self):
+        result = normalize_concept("Kubernetes (k8s)", level=3)
+        assert "k8s" not in result
+        assert "kubernetes" in result
+
+    def test_level_3_removes_punctuation(self):
+        assert normalize_concept("hello, world!", level=3) == "hello world"
+
+    def test_level_4_folds_whitespace(self):
+        assert normalize_concept("machine learning", level=4) == "machinelearning"
+        assert normalize_concept("state   machine", level=4) == "statemachine"
+
+
+class TestCanonicalizeConcept:
+    def test_lowercases_and_strips_punctuation(self):
+        result = canonicalize_concept("Machine-Learning")
+        assert result == "machine learning"
+
+    def test_removes_brackets(self):
+        result = canonicalize_concept("Extreme Programming (XP)")
+        assert result == "extreme programming"
+
+
+class TestFingerprintConcept:
+    def test_equivalent_variants_produce_same_fingerprint(self):
+        variants = [
+            "machine learning",
+            "machine-learning",
+            "machine_learning",
+            "Machine Learning",
+            "machine  learning",
+        ]
+        fingerprints = {fingerprint_concept(v) for v in variants}
+        assert len(fingerprints) == 1
+        assert fingerprints == {"machinelearning"}
+
+    def test_bracket_content_removed(self):
+        assert fingerprint_concept("Kubernetes (k8s)") == fingerprint_concept("kubernetes")
+
+    def test_separators_equivalent_to_spaces(self):
+        assert fingerprint_concept("api/gateway") == fingerprint_concept("api gateway")
+
+    def test_punctuation_removed(self):
+        assert fingerprint_concept("Hello, World!") == fingerprint_concept("hello world")
+
+    def test_leading_trailing_whitespace_ignored(self):
+        assert fingerprint_concept("  concept  ") == fingerprint_concept("concept")
+
+
+class TestHashConcepts:
+    def test_deterministic(self):
+        concepts = ["Machine Learning", "Deep Learning"]
+        h1 = hash_concepts(concepts)
+        h2 = hash_concepts(list(reversed(concepts)))
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_different_concepts_produce_different_hash(self):
+        h1 = hash_concepts(["A", "B"])
+        h2 = hash_concepts(["A", "C"])
+        assert h1 != h2


### PR DESCRIPTION
## Summary

Replace `.lower()` with `fingerprint_concept()` for concept dedup in `_merge_chunk_results`.

## Why

While LLMs often auto-standardize concept names (e.g., `spring-boot` → `Spring Boot`), this is not guaranteed for smaller models or manual edits. The previous `.lower()` approach missed format variants like `machine learning` vs `machine-learning` vs `machine_learning`. This change adds a robust normalization layer to handle such cases.

## Changes

- Use `fingerprint_concept()` as the dedup key

- Add 14 unit tests in `test_text_utils.py`

- Add integration tests in `test_ingest.py`

- Move `import hashlib` to module top

## Testing

```bash

uv run pytest tests/test_text_utils.py tests/test_ingest.py -k merge -v

# 22 tests passed

```

---

*Note: I am a Java developer, not a Python developer. This PR was written with assistance from AI. Please feel free to point out any issues.*