### PR TITLE
Add Docker deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+
+# Test and docs
+tests/
+docs/
+scripts/
+
+# Git and editor artifacts
+.git/
+.gitignore
+.DS_Store
+*.log
+.env
+
+# uv / lock files (exclude for latest-compatible builds; include for fully-reproducible builds)
+uv.lock
+
+# Lint / cache artifacts
+.ruff_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Local planning / review artifacts
+CONTEXT.md
+REQUIREMENTS.md
+IMPLEMENTATION_PLAN.md
+IMPLEMENTAION_PLAN.md
+REVIEW.md
+
+# Docker artifacts
+Dockerfile
+docker-compose.yml
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: builder ──────────────────────────────────────────────────────────
+FROM python:3.11-slim AS builder
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /src
+COPY . .
+
+# Install the package into a dedicated prefix
+RUN uv pip install --system --prefix /opt/olw .
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+FROM python:3.11-slim
+
+# Git is required for auto-commit functionality
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Mark every directory as safe so bind-mounted vaults (owned by host UID) work
+RUN git config --global safe.directory '*'
+
+# Copy installed environment from builder
+COPY --from=builder /opt/olw /opt/olw
+
+ENV PATH="/opt/olw/bin:${PATH}" \
+    PYTHONPATH="/opt/olw/lib/python3.11/site-packages"
+
+ENTRYPOINT ["olw"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  olw:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    stdin_open: true
+    tty: true
+    environment:
+      OLW_VAULT: /vault
+      # Cloud provider API keys (pass through from host if needed)
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      OLW_API_KEY: ${OLW_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    volumes:
+      - ${HOST_VAULT_PATH}:/vault
+      - ${OLW_CONFIG_PATH:-~/.config/olw}:/root/.config/olw
+      - ~/.gitconfig:/root/.gitconfig:ro
+    # Linux users: uncomment the line below if host.docker.internal does not resolve
+    # extra_hosts:
+    #   - "host.docker.internal:host-gateway"
+    # Or use --network host on Linux when running against a local Ollama instance:
+    # network_mode: host


### PR DESCRIPTION
Closes #43

## Summary

Adds Docker and docker-compose support for running `olw` without a local Python install.

## Changes

1. **`.dockerignore`** — excludes tests/, docs/, scripts/, .git, pycache, *.pyc, uv.lock, .ruff_cache, .claude/, Dockerfile, docker-compose.yml, and editor artifacts.

2. **`Dockerfile`** — multi-stage build:
   - **Stage 1 (builder):** `python:3.11-slim` + install `uv` + `uv pip install --system --prefix /opt/olw .`
   - **Stage 2 (runtime):** `python:3.11-slim` + `apt-get install git` + copy `/opt/olw` from builder + set `PATH=/opt/olw/bin:$PATH` and `PYTHONPATH=/opt/olw/lib/python3.11/site-packages`
   - One-time `git config --global safe.directory '*'` baked into the image (handles ownership mismatch when vault bind-mount is owned by host user)
   - `ENTRYPOINT ["olw"]`, `CMD ["--help"]`
   - No entrypoint script — the image only ships the program

3. **`docker-compose.yml`** — single service `olw`:
   - Built from `.`, `stdin_open: true`, `tty: true` (for review command)
   - Three bind mounts from host:
     - `${HOST_VAULT_PATH}:/vault` — vault (raw notes, wiki, state DB)
     - `${OLW_CONFIG_PATH:-~/.config/olw}:/root/.config/olw` — global config (`config.toml`)
     - `~/.gitconfig:/root/.gitconfig:ro` — git identity for auto-commits (read-only)
   - Env: `OLW_VAULT=/vault`
   - Cloud provider keys passed via env vars if needed: `GROQ_API_KEY`, `OLW_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`

## Verification

```bash
# Build image
docker build -t olw:local .

# Basic smoke (no vault needed)
docker run --rm olw:local --help

# Full integration test (requires vault path)
HOST_VAULT_PATH=/path/to/test-vault docker compose run olw doctor
HOST_VAULT_PATH=/path/to/test-vault docker compose run olw ingest --all
```

## Caveats

- Ollama on host (Mac/Windows): in `~/.config/olw/config.toml` set `provider_url = "http://host.docker.internal:11434"`. On Linux, `host.docker.internal` doesn't resolve — use `extra_hosts` or `--network host`.
- `olw setup` writes to `~/.config/olw/config.toml` which is the mounted host file — changes persist correctly.
- `watch` command: inotify works on Linux Docker. Mac Docker Desktop VirtioFS (4.6+) passes events through; older osxfs may not.
- `review` command: interactive; use `docker compose run -it olw review`.