### PR TITLE
fix: show optional API key prompt for local providers in setup wizard

### DIFF
--- a/src/obsidian_llm_wiki/cli.py
+++ b/src/obsidian_llm_wiki/cli.py
@@ -673,17 +673,17 @@ def setup(non_interactive: bool, reset: bool, provider_preset: str | None):
             )
             sys.exit(1)
 
-        # ── Step 3 — API key (cloud + custom providers) ───────────────────────
+        # ── Step 3 — API key (all non-Ollama providers; optional for local) ─────
         import os
 
-        needs_key_prompt = chosen_prov.requires_auth or chosen_name == "custom"
+        needs_key_prompt = chosen_name != "ollama"
         api_key: str | None = None
         if needs_key_prompt:
             console.print()
             console.print("  [bold]Step 3[/bold]  API key")
             if chosen_prov.env_var:
                 env_hint = f"  [dim](or set {chosen_prov.env_var} env var)[/dim]"
-            elif chosen_name == "custom":
+            elif not chosen_prov.requires_auth:
                 env_hint = "  [dim](optional — press Enter to skip)[/dim]"
             else:
                 env_hint = ""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -638,3 +638,26 @@ def test_doctor_prints_graph_guidance(runner: CliRunner, cfg_dir: Path, tmp_path
     assert "Published-only graph filter" in result.output
     assert "-path:raw" in result.output
     assert "-file:Welcome" in result.output
+
+
+def test_setup_wizard_vllm_saves_api_key(runner: CliRunner, cfg_dir: Path):
+    """Selecting vLLM in the wizard should prompt for an optional API key and persist it."""
+    with patch("obsidian_llm_wiki.openai_compat_client.OpenAICompatClient") as MockClient:
+        instance = MagicMock()
+        instance.healthcheck.return_value = False
+        instance.list_models_detailed.return_value = []
+        MockClient.return_value = instance
+
+        result = runner.invoke(
+            cli,
+            ["setup"],
+            # provider=vllm, URL default, api_key, fast model, heavy model, no vault, citations off
+            input="vllm\n\nmy-enterprise-key\nllama3\nllama3\n\nn\n",
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    cfg = load_global_config()
+    assert cfg is not None
+    assert cfg.provider_name == "vllm"
+    assert cfg.api_key == "my-enterprise-key"

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "obsidian-llm-wiki"
-version = "0.8.1"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Local providers (vLLM, LM Studio, etc.) can be deployed with key verification in enterprise environments, but the wizard previously only prompted for a key on cloud or custom providers. Expand the condition so all non-Ollama providers get the Step 3 prompt (optional for local, required for cloud). No schema or client changes needed — GlobalConfig and OpenAICompatClient already handle the key end-to-end.

Closes #64