### PR TITLE
fix: sanitize malformed LaTeX delimiters in LLM output (issue #67)

### DIFF
--- a/src/obsidian_llm_wiki/markdown_math.py
+++ b/src/obsidian_llm_wiki/markdown_math.py
@@ -1,0 +1,120 @@
+"""
+Obsidian math sanitization.
+
+Converts LLM LaTeX output to Obsidian-friendly math delimiters:
+  \\[ ... \\]  →  $$ ... $$
+  bare \\frac{a}{b} lines  →  $$ \\frac{a}{b} $$
+
+Leaf module — no project imports.
+"""
+
+from __future__ import annotations
+
+import re
+
+_INLINE_MATH_RE = r"(?<!\$)\$(?!\$)(?:\\.|[^$\n])+?(?<!\\)\$(?!\$)"
+_BASE_MASK_PARTS = [
+    r"```[\s\S]*?```",
+    r"`[^`]+`",
+    r"\$\$[\s\S]*?\$\$",
+    _INLINE_MATH_RE,
+    r"\\\([\s\S]*?\\\)",
+    r"!\[[^\]]*\]\([^)]*\)",
+    r"\[[^\]\n]+\]\([^)]*\)",
+]
+_OBSIDIAN_EMBED_RE = r"!\[\[[\s\S]*?\]\]"
+_WIKILINK_RE = r"\[\[[^\]]+\]\]"
+_DISPLAY_MATH_RE = re.compile(r"\\{1,2}\[(.*?)\\{1,2}\]", re.DOTALL)
+_BARE_LATEX_LINE_RE = re.compile(r"^(?P<indent>[ \t]*)(?P<body>\\{1,2}[A-Za-z{_].*)$")
+_LATEX_COMMAND_RE = re.compile(
+    r"^\\(?:begin|end|frac|sqrt|sum|prod|int|lim|alpha|beta|gamma|delta|theta|lambda|mu|pi|sigma|phi|psi|omega|sin|cos|tan|log|ln|exp|cdot|times|leq|geq|neq|approx|left|right|text|mathrm|mathbf|mathit|operatorname)\b"
+)
+_MATH_SIGNAL_RE = re.compile(r"[{}_^=]|\\(?:[A-Za-z]+|[,;! ])")
+
+
+def mask_markdown_regions(
+    content: str, *, mask_wikilinks: bool = True, mask_embeds: bool = True
+) -> tuple[str, list[tuple[str, str]]]:
+    """Protect markdown regions that should not be rewritten."""
+    replacements: list[tuple[str, str]] = []
+    parts = list(_BASE_MASK_PARTS)
+    if mask_embeds:
+        parts.append(_OBSIDIAN_EMBED_RE)
+    if mask_wikilinks:
+        parts.append(_WIKILINK_RE)
+    pattern = re.compile("|".join(parts), re.MULTILINE)
+
+    def replace(match: re.Match[str]) -> str:
+        token = f"__OBSIDIAN_LLM_WIKI_MASK_{len(replacements)}__"
+        replacements.append((token, match.group(0)))
+        return token
+
+    return pattern.sub(replace, content), replacements
+
+
+def restore_markdown_regions(content: str, replacements: list[tuple[str, str]]) -> str:
+    for token, original in replacements:
+        content = content.replace(token, original)
+    return content
+
+
+def _display_math_repl(match: re.Match[str]) -> str:
+    inner = match.group(1).strip()
+    if not inner:
+        return match.group(0)
+    return f"$$\n{inner}\n$$"
+
+
+def _looks_like_bare_latex_line(stripped: str) -> bool:
+    if stripped.startswith(("\\[", "\\\\[", "\\(", "\\\\(")):
+        return False
+    if stripped.startswith(("#", ">", "- ", "* ", "+ ", "|")):
+        return False
+    if re.match(r"\d+\.\s", stripped):
+        return False
+    if _LATEX_COMMAND_RE.match(stripped):
+        return True
+    normalized = stripped.lstrip("\\")
+    return bool(_MATH_SIGNAL_RE.search(normalized))
+
+
+def sanitize_obsidian_math(content: str) -> str:
+    """Normalize LLM LaTeX output to Obsidian-friendly math delimiters."""
+    masked, replacements = mask_markdown_regions(content)
+    masked = _DISPLAY_MATH_RE.sub(_display_math_repl, masked)
+
+    lines: list[str] = []
+    for line in masked.splitlines(keepends=True):
+        line_ending = ""
+        if line.endswith("\r\n"):
+            line_ending = "\r\n"
+            raw = line[:-2]
+        elif line.endswith("\n"):
+            line_ending = "\n"
+            raw = line[:-1]
+        else:
+            raw = line
+
+        match = _BARE_LATEX_LINE_RE.match(raw)
+        if not match:
+            lines.append(line)
+            continue
+
+        indent = match.group("indent")
+        stripped = match.group("body").strip()
+        if not _looks_like_bare_latex_line(stripped):
+            lines.append(line)
+            continue
+
+        if stripped.startswith("\\\\") and not stripped.startswith("\\\\\\"):
+            stripped = stripped[1:]
+
+        ending = line_ending or "\n"
+        lines.append(f"{indent}$$ {stripped} $${ending}")
+
+    sanitized = "".join(lines)
+    return restore_markdown_regions(sanitized, replacements)
+
+
+def has_malformed_obsidian_math(content: str) -> bool:
+    return sanitize_obsidian_math(content) != content

--- a/src/obsidian_llm_wiki/pipeline/compile.py
+++ b/src/obsidian_llm_wiki/pipeline/compile.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import frontmatter as fm_lib
 
 from ..config import Config
+from ..markdown_math import sanitize_obsidian_math
 from ..models import ArticlePlan, CompilePlan, SingleArticle, WikiArticleRecord
 from ..openai_compat_client import LLMBadRequestError, LLMTruncatedError
 from ..protocols import LLMClientProtocol
@@ -611,6 +612,7 @@ def _write_draft(
 
     # Inject wikilinks for known article titles mentioned in body
     body = _repair_literal_newlines(content_result.content)
+    body = sanitize_obsidian_math(body)
     body = _repair_malformed_embeds(body)
     body = _repair_bare_bracket_links(body)
     body = ensure_wikilinks(body, existing_titles or [])

--- a/src/obsidian_llm_wiki/pipeline/query.py
+++ b/src/obsidian_llm_wiki/pipeline/query.py
@@ -23,6 +23,7 @@ import frontmatter
 
 from ..config import Config
 from ..indexer import append_log, generate_index
+from ..markdown_math import sanitize_obsidian_math
 from ..models import PageSelection, QueryAnswer, WikiArticleRecord
 from ..protocols import LLMClientProtocol
 from ..state import (
@@ -204,7 +205,7 @@ def _strip_unknown_wikilinks(content: str, known_titles: list[str]) -> str:
 def _sanitize_query_answer(answer: str, source_pages: list[str], known_titles: list[str]) -> str:
     """Strip invented wikilinks from query answers before returning or saving."""
     allowed_titles = [*known_titles, *source_pages]
-    return _strip_unknown_wikilinks(answer, allowed_titles)
+    return _strip_unknown_wikilinks(sanitize_obsidian_math(answer), allowed_titles)
 
 
 def _body_hash(body: str) -> str:

--- a/tests/test_markdown_math.py
+++ b/tests/test_markdown_math.py
@@ -1,0 +1,20 @@
+"""Tests for markdown_math.sanitize_obsidian_math."""
+
+from __future__ import annotations
+
+from obsidian_llm_wiki.markdown_math import sanitize_obsidian_math
+
+
+def test_sanitize_converts_display_math():
+    body = sanitize_obsidian_math("Before \\[\nE = mc^2\n\\] after")
+    assert body == "Before $$\nE = mc^2\n$$ after"
+
+
+def test_sanitize_wraps_bare_latex_line():
+    body = sanitize_obsidian_math("\\frac{a}{b}\n")
+    assert body == "$$ \\frac{a}{b} $$\n"
+
+
+def test_sanitize_keeps_code_and_existing_math_unchanged():
+    body = sanitize_obsidian_math("`\\frac{a}{b}`\n$$\nE = mc^2\n$$\n")
+    assert body == "`\\frac{a}{b}`\n$$\nE = mc^2\n$$\n"


### PR DESCRIPTION
## Summary

- Adds `src/obsidian_llm_wiki/markdown_math.py` — ports synto's `sanitize_obsidian_math()` to convert `\[ ... \]` display math and bare LaTeX lines (e.g. `\frac{a}{b}`) to Obsidian-compatible `$$ ... $$` notation
- Wires sanitization into the compile pipeline (`_write_draft`, after `_repair_literal_newlines`) and the query pipeline (`_sanitize_query_answer`)
- Protects existing code blocks and math regions via masking before rewriting — no double-processing

Closes #67

## Test plan

- [x] 3 unit tests in `tests/test_markdown_math.py` (display math, bare LaTeX, code/math preservation)
- [x] Full test suite: 779 passed, 1 skipped
- [x] Main smoke test: 111/111 checks passed
- [x] Compare smoke test: 23/23 checks passed
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)